### PR TITLE
Complete API references in docs and include in mkdocs (closes #6)

### DIFF
--- a/docs/reference/api/dashboard.md
+++ b/docs/reference/api/dashboard.md
@@ -1,0 +1,48 @@
+# Dashboard API
+
+This document provides information about the dashboard endpoints of the FastAPI RBAC API.
+
+## Dashboard Endpoints
+
+### GET /api/v1/dashboard/overview
+Retrieve system overview metrics for the dashboard.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Response:**
+```json
+{
+  "data": {
+    "user_count": 100,
+    "active_users": 80,
+    "role_count": 5,
+    "permission_count": 20
+  }
+}
+```
+
+### GET /api/v1/dashboard/activity
+Retrieve recent activity logs for the dashboard.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "timestamp": "2025-07-08T12:00:00Z",
+      "actor": "admin@example.com",
+      "action": "user.created",
+      "resource": "user",
+      "resource_id": "uuid-string"
+    }
+  ]
+}
+```

--- a/docs/reference/api/permission_groups.md
+++ b/docs/reference/api/permission_groups.md
@@ -1,0 +1,101 @@
+# Permission Groups API
+
+This document provides information about the permission group management endpoints of the FastAPI RBAC API.
+
+## Permission Group Endpoints
+
+### GET /api/v1/permission-groups
+Retrieve a list of permission groups.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "uuid-string",
+      "name": "user-management",
+      "description": "User management permissions"
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "limit": 20,
+    "total": 1,
+    "pages": 1
+  }
+}
+```
+
+### POST /api/v1/permission-groups
+Create a new permission group.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Request Body:**
+```json
+{
+  "name": "admin-permissions",
+  "description": "Admin permissions group"
+}
+```
+
+**Response:**
+```json
+{
+  "data": {
+    "id": "uuid-string",
+    "name": "admin-permissions",
+    "description": "Admin permissions group"
+  }
+}
+```
+
+### PATCH /api/v1/permission-groups/{permission_group_id}
+Update a permission group.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Request Body:**
+```json
+{
+  "name": "updated_group",
+  "description": "Updated description"
+}
+```
+
+**Response:**
+```json
+{
+  "data": {
+    "id": "uuid-string",
+    "name": "updated_group",
+    "description": "Updated description"
+  }
+}
+```
+
+### DELETE /api/v1/permission-groups/{permission_group_id}
+Delete a permission group.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Response:**
+```json
+{
+  "message": "Permission group deleted successfully"
+}
+```

--- a/docs/reference/api/permissions.md
+++ b/docs/reference/api/permissions.md
@@ -1,0 +1,101 @@
+# Permissions API
+
+This document provides information about the permission management endpoints of the FastAPI RBAC API.
+
+## Permission Endpoints
+
+### GET /api/v1/permissions
+Retrieve a list of permissions.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "uuid-string",
+      "name": "user.create",
+      "description": "Create user permission"
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "limit": 20,
+    "total": 1,
+    "pages": 1
+  }
+}
+```
+
+### POST /api/v1/permissions
+Create a new permission.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Request Body:**
+```json
+{
+  "name": "user.delete",
+  "description": "Delete user permission"
+}
+```
+
+**Response:**
+```json
+{
+  "data": {
+    "id": "uuid-string",
+    "name": "user.delete",
+    "description": "Delete user permission"
+  }
+}
+```
+
+### PATCH /api/v1/permissions/{permission_id}
+Update a permission.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Request Body:**
+```json
+{
+  "name": "user.update",
+  "description": "Update user permission"
+}
+```
+
+**Response:**
+```json
+{
+  "data": {
+    "id": "uuid-string",
+    "name": "user.update",
+    "description": "Update user permission"
+  }
+}
+```
+
+### DELETE /api/v1/permissions/{permission_id}
+Delete a permission.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Response:**
+```json
+{
+  "message": "Permission deleted successfully"
+}
+```

--- a/docs/reference/api/role_groups.md
+++ b/docs/reference/api/role_groups.md
@@ -1,0 +1,101 @@
+# Role Groups API
+
+This document provides information about the role group management endpoints of the FastAPI RBAC API.
+
+## Role Group Endpoints
+
+### GET /api/v1/role-groups
+Retrieve a list of role groups.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "uuid-string",
+      "name": "core-admins",
+      "description": "Core admin group"
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "limit": 20,
+    "total": 1,
+    "pages": 1
+  }
+}
+```
+
+### POST /api/v1/role-groups
+Create a new role group.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Request Body:**
+```json
+{
+  "name": "managers",
+  "description": "Managers group"
+}
+```
+
+**Response:**
+```json
+{
+  "data": {
+    "id": "uuid-string",
+    "name": "managers",
+    "description": "Managers group"
+  }
+}
+```
+
+### PATCH /api/v1/role-groups/{role_group_id}
+Update a role group.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Request Body:**
+```json
+{
+  "name": "updated_group",
+  "description": "Updated description"
+}
+```
+
+**Response:**
+```json
+{
+  "data": {
+    "id": "uuid-string",
+    "name": "updated_group",
+    "description": "Updated description"
+  }
+}
+```
+
+### DELETE /api/v1/role-groups/{role_group_id}
+Delete a role group.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Response:**
+```json
+{
+  "message": "Role group deleted successfully"
+}
+```

--- a/docs/reference/api/roles.md
+++ b/docs/reference/api/roles.md
@@ -1,0 +1,101 @@
+# Roles API
+
+This document provides information about the role management endpoints of the FastAPI RBAC API.
+
+## Role Endpoints
+
+### GET /api/v1/roles
+Retrieve a list of roles.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "uuid-string",
+      "name": "admin",
+      "description": "Administrator role"
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "limit": 20,
+    "total": 1,
+    "pages": 1
+  }
+}
+```
+
+### POST /api/v1/roles
+Create a new role.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Request Body:**
+```json
+{
+  "name": "manager",
+  "description": "Manager role"
+}
+```
+
+**Response:**
+```json
+{
+  "data": {
+    "id": "uuid-string",
+    "name": "manager",
+    "description": "Manager role"
+  }
+}
+```
+
+### PATCH /api/v1/roles/{role_id}
+Update a role.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Request Body:**
+```json
+{
+  "name": "updated_name",
+  "description": "Updated description"
+}
+```
+
+**Response:**
+```json
+{
+  "data": {
+    "id": "uuid-string",
+    "name": "updated_name",
+    "description": "Updated description"
+  }
+}
+```
+
+### DELETE /api/v1/roles/{role_id}
+Delete a role.
+
+**Request Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Response:**
+```json
+{
+  "message": "Role deleted successfully"
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,11 @@ nav:
       - "Overview": "reference/index.md"
       - "Authentication": "reference/api/auth.md"
       - "Users": "reference/api/users.md"
+      - "Roles": "reference/api/roles.md"
+      - "Permissions": "reference/api/permissions.md"
+      - "Role Groups": "reference/api/role_groups.md"
+      - "Permission Groups": "reference/api/permission_groups.md"
+      - "Dashboard": "reference/api/dashboard.md"
   - "Release Notes": "release-notes.md"
   - "Contributing": "contributing.md"
 


### PR DESCRIPTION
This PR addresses issue #6 by creating the missing API documentation and ensuring it is included in the mkdocs documentation site.

**Steps completed in this PR:**
1. Added API reference markdown files for roles, permissions, role groups, permission groups, and dashboard in `docs/reference/api/`.
2. Updated `mkdocs.yml` to include all new API reference files in the navigation.
3. Verified documentation build and navigation locally.

**Next steps:**
- Review the new documentation for accuracy and completeness.
- Approve and merge the PR to main.

Closes #6.