### PR TITLE
chore(deps): Lane 7 align Docker/CI base images (#37)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -67,7 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:15
+        # Keep in sync with backend docker-compose*.yml (postgres:15-alpine)
+        image: postgres:15-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -82,7 +83,8 @@ jobs:
           --health-retries 5
 
       redis:
-        image: redis:6
+        # Keep in sync with backend docker-compose*.yml (redis:7.2-alpine)
+        image: redis:7.2-alpine
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/react-frontend-ci.yml
+++ b/.github/workflows/react-frontend-ci.yml
@@ -88,8 +88,9 @@ jobs:
         run: npm run build
 
   # Playwright E2E requires a live FastAPI backend (Postgres, Redis, seeded admin,
-  # CSRF-aware login). This workflow never started that stack, so the job has been
-  # failing since E2E was added. Re-enable when full-stack CI is wired (#30 / #37).
+  # CSRF-aware login). Image tags are aligned with compose/CI services (#37), but this
+  # job still does not start the backend stack. Keep skipped until a dedicated
+  # full-stack E2E workflow is added (follow-up under #30).
   e2e-tests:
     name: E2E Tests
     if: ${{ false }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,7 @@
 # Supports development, testing, and production environments
 
 # Base stage with common dependencies
-FROM python:3.10-slim-bullseye AS base
+FROM python:3.10-slim-bookworm AS base
 
 WORKDIR /app
 

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -2,7 +2,7 @@
 # Multi-stage build for a production-ready FastAPI application
 
 # BUILD STAGE
-FROM python:3.10-slim-bullseye AS builder
+FROM python:3.10-slim-bookworm AS builder
 
 # Set work directory
 WORKDIR /app
@@ -26,7 +26,7 @@ COPY requirements.txt .
 RUN pip wheel --no-cache-dir --no-deps --wheel-dir /app/wheels -r requirements.txt
 
 # FINAL STAGE
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 # Create a non-root user
 RUN useradd -m -u 1000 appuser

--- a/backend/docker-compose.dev.yml
+++ b/backend/docker-compose.dev.yml
@@ -194,7 +194,7 @@ services:
 
   # Redis for development
   fastapi_rbac_redis_dev:
-    image: redis:7.2.5-alpine
+    image: redis:7.2-alpine
     container_name: fastapi_rbac_redis_dev
     restart: always
     ports:

--- a/backend/docker-compose.prod.yml
+++ b/backend/docker-compose.prod.yml
@@ -29,7 +29,7 @@ services:
       - fastapi_rbac_prod_network
 
   fastapi_rbac_redis_prod:
-    image: redis:7.2.5-alpine
+    image: redis:7.2-alpine
     container_name: fastapi_rbac_redis_prod
     restart: always
     command: >

--- a/backend/docker-compose.test.minimal.yml
+++ b/backend/docker-compose.test.minimal.yml
@@ -113,7 +113,7 @@ services:
 
   # Redis Cache for testing
   fastapi_rbac_redis_test:
-    image: redis:7.2.5-alpine
+    image: redis:7.2-alpine
     restart: always
     container_name: fastapi_rbac_redis_test
     ports:

--- a/backend/docker-compose.test.yml
+++ b/backend/docker-compose.test.yml
@@ -33,7 +33,7 @@ services:
 
   # Redis Cache for testing
   fastapi_rbac_redis_test:
-    image: redis:7.2.5-alpine
+    image: redis:7.2-alpine
     restart: always
     container_name: fastapi_rbac_redis_test
     ports:

--- a/backend/docs/REDIS_SSL_SETUP.md
+++ b/backend/docs/REDIS_SSL_SETUP.md
@@ -151,7 +151,7 @@ The `docker-compose.prod.yml` configures Redis with SSL:
 
 ```yaml
 fastapi_rbac_redis_prod:
-  image: redis:7.2.5-alpine
+  image: redis:7.2-alpine
   command: >
     redis-server
     --tls-port 6379

--- a/backend/queue.dockerfile
+++ b/backend/queue.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /app
 

--- a/backend/queue.dockerfile.prod
+++ b/backend/queue.dockerfile.prod
@@ -2,7 +2,7 @@
 # Multi-stage build for Celery workers, beat, and flower in production
 
 # BUILD STAGE
-FROM python:3.10-slim-bullseye AS builder
+FROM python:3.10-slim-bookworm AS builder
 
 # Set work directory
 WORKDIR /app
@@ -32,7 +32,7 @@ RUN rm -rf /app/wheels && mkdir /app/wheels && \
     ls -l /app/wheels
 
 # FINAL STAGE
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 # Create a non-root user
 RUN useradd -m -u 1000 appuser

--- a/docs/development/DEPENDENCY_UPGRADES.md
+++ b/docs/development/DEPENDENCY_UPGRADES.md
@@ -150,7 +150,20 @@ Spike landed in one PR (stack was already on React 19 / Tailwind 4 / RR7):
 | `zod` | `3.25` → `4.4.3` | Existing `message` args still work (deprecated); prefer `error` later |
 | `recharts` | `2.15` → `3.9.2` | Dashboard `AreaChart` OK |
 
-**Deferred (narrower follow-ups):** Vite 8 + `@vitejs/plugin-react` 6 (Rolldown/Babel compiler peers), TypeScript 7. Playwright e2e remains gated until full-stack CI (#37).
+**Deferred (narrower follow-ups):** Vite 8 + `@vitejs/plugin-react` 6 (Rolldown/Babel compiler peers), TypeScript 7. Playwright e2e remains gated until a dedicated full-stack E2E workflow (image alignment done in Lane 7).
+
+### Lane 7 notes (2026-07-17)
+
+Aligned Docker/CI base images:
+
+| Surface | Aligned tag |
+|---------|-------------|
+| Backend Dockerfiles | `python:3.10-slim-bookworm` |
+| Frontend Dockerfiles | `node:20-alpine` (matches CI Node 20 + `package.json` `engines`) |
+| Compose Postgres | `postgres:15-alpine` (CI now matches) |
+| Compose / CI Redis | `redis:7.2-alpine` (was CI `redis:6` / compose `7.2.5-alpine`) |
+
+Playwright e2e job remains `if: false` — needs a workflow that starts API + DB + Redis + seeded admin; track as follow-up under #30.
 
 ## Per-PR checklist
 

--- a/docs/troubleshooting/DOCKER_ISSUES.md
+++ b/docs/troubleshooting/DOCKER_ISSUES.md
@@ -169,8 +169,8 @@ This guide covers common Docker-related issues and their solutions for the FastA
 2. **Update Base Images**
    ```powershell
    # Pull latest base images
-   docker pull python:3.10-slim
-   docker pull node:18-alpine
+   docker pull python:3.10-slim-bookworm
+   docker pull node:20-alpine
    ```
 
 ## 🌐 Networking Issues

--- a/react-frontend/Dockerfile
+++ b/react-frontend/Dockerfile
@@ -2,7 +2,7 @@
 # Supports development, testing, and production environments
 
 # Base stage with common dependencies
-FROM node:18-alpine AS base
+FROM node:20-alpine AS base
 
 WORKDIR /app
 

--- a/react-frontend/Dockerfile.prod
+++ b/react-frontend/Dockerfile.prod
@@ -2,7 +2,7 @@
 # Multi-stage build for a production-ready React application
 
 # BUILD STAGE
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 
 # Set working directory
 WORKDIR /app

--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary
Align Docker/CI base images for Lane 7 (#37):

| Surface | Change |
|---------|--------|
| Frontend Dockerfiles | `node:18-alpine` → `node:20-alpine` (matches CI Node 20) |
| Backend Dockerfiles | `python:3.10-slim-bullseye` → `python:3.10-slim-bookworm` |
| Backend CI services | `postgres:15` → `postgres:15-alpine`, `redis:6` → `redis:7.2-alpine` |
| Compose Redis | `redis:7.2.5-alpine` → `redis:7.2-alpine` (same minor line as CI) |
| `package.json` | `engines.node: ">=20"` |

- Docs updated (`DEPENDENCY_UPGRADES.md`, Docker troubleshooting, Redis SSL example)
- Playwright e2e remains skipped: image drift is fixed, but the job still does not start the FastAPI stack — track a dedicated full-stack E2E workflow as a follow-up under #30

Fixes #37
Related to #30

## Test plan
- [x] `docker compose … config` for dev/prod — OK
- [x] Pulled `node:20-alpine`, `python:3.10-slim-bookworm`, `postgres:15-alpine`, `redis:7.2-alpine`
- [x] Smoke-built frontend (`Dockerfile` development) and backend (`Dockerfile` development) images
- [x] Backend CI + Frontend CI green
- [ ] Optional: recreate local compose stack with new Redis tag