### PR TITLE
Add Matt Pocock implement skill

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -13,6 +13,7 @@ Reachable only when you type them (`disable-model-invocation: true`).
 - **[setup-matt-pocock-skills](./setup-matt-pocock-skills/SKILL.md)** — Configure this repo for the engineering skills (issue tracker, triage labels, domain doc layout). Run once per repo.
 - **[to-issues](./to-issues/SKILL.md)** — Break any plan, spec, or PRD into independently-grabbable issues using vertical slices.
 - **[to-prd](./to-prd/SKILL.md)** — Turn the current conversation into a PRD and publish it to the issue tracker.
+- **[implement](./implement/SKILL.md)** — Implement a piece of work from a spec or tickets (drives `/tdd`, then `/code-review`, then commits).
 
 ## Model-invoked
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: implement
+description: "Implement a piece of work based on a spec or set of tickets."
+disable-model-invocation: true
+---
+
+Implement the work described by the user in the spec or tickets.
+
+Use /tdd where possible, at pre-agreed seams.
+
+Run typechecking regularly, single test files regularly, and the full test suite once at the end.
+
+Once done, use /code-review to review the work.
+
+Commit your work to the current branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository includes Matt Pocock engineering skills in `.claude/skills`.
 
 Use these skills as available workflows:
 
-- User-invoked: `ask-matt`, `grill-with-docs`, `triage`, `improve-codebase-architecture`, `setup-matt-pocock-skills`, `to-issues`, `to-prd`
+- User-invoked: `ask-matt`, `grill-with-docs`, `triage`, `improve-codebase-architecture`, `setup-matt-pocock-skills`, `to-issues`, `to-prd`, `implement`
 - Model-invoked: `prototype`, `diagnosing-bugs`, `research`, `tdd`, `domain-modeling`, `codebase-design`, `code-review`
 
 ## Agent skills


### PR DESCRIPTION
## Summary
- Add the user-invoked `implement` skill from mattpocock/skills so agents can build from a spec/tickets.
- Document it in `.claude/skills/README.md` and `AGENTS.md`; it drives existing `/tdd` then `/code-review`.

## Test plan
- [x] Confirm `.claude/skills/implement/SKILL.md` matches upstream content
- [x] Confirm `/implement` is listed under user-invoked skills in README and AGENTS.md
- [x] Spot-check that `tdd` and `code-review` skills already exist (dependencies)

Made with [Cursor](https://cursor.com)