### PR TITLE
fix(auth): restore typed JWT security audit events

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -19,7 +19,11 @@ from app.api import deps
 from app.api.deps import get_redis_client, get_strict_sanitizer
 from app.core import security  # security module contains token functions
 from app.core.config import ModeEnum, settings
-from app.core.security import PasswordValidator, decode_token  # For password complexity
+from app.core.security import (  # For password complexity / JWT audit mapping
+    PasswordValidator,
+    decode_token,
+    map_jwt_http_error_to_event,
+)
 from app.models.user_model import User
 from app.schemas.common_schema import TokenType
 from app.schemas.response_schema import IPostResponseBase, create_response
@@ -677,7 +681,19 @@ async def verify_email(
         )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid input data")
     try:
-        payload = security.decode_token(body.token, token_type="verification")
+        try:
+            payload = security.decode_token(body.token, token_type="verification")
+        except HTTPException as exc:
+            background_tasks.add_task(
+                log_security_event,
+                background_tasks=background_tasks,
+                event_type=map_jwt_http_error_to_event(exc, flow="verify_email"),
+                details={
+                    "error": (exc.detail if isinstance(exc.detail, str) else str(exc.detail)),
+                    "ip_address": ip_address,
+                },
+            )
+            raise
         email_from_token_str = payload.get("sub")
         if not email_from_token_str:
             background_tasks.add_task(
@@ -1188,7 +1204,19 @@ async def get_new_access_token(
     ip_address = request.client.host if request.client else "Unknown"  # Get IP address
     payload = None  # Initialize payload for broader scope in exception handling
     try:
-        payload = decode_token(body.refresh_token, token_type="refresh")
+        try:
+            payload = decode_token(body.refresh_token, token_type="refresh")
+        except HTTPException as exc:
+            background_tasks.add_task(
+                log_security_event,
+                background_tasks=background_tasks,
+                event_type=map_jwt_http_error_to_event(exc, flow="refresh"),
+                details={
+                    "token_error": (exc.detail if isinstance(exc.detail, str) else str(exc.detail)),
+                    "ip_address": ip_address,
+                },
+            )
+            raise
         if payload["type"] == "refresh":
             user_id_from_token = payload["sub"]
             valid_refresh_tokens = await get_valid_tokens(redis_client, user_id_from_token, TokenType.REFRESH)

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -229,6 +229,39 @@ def decode_token(
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token validation failed")
 
 
+def map_jwt_http_error_to_event(
+    exc: HTTPException,
+    *,
+    flow: Literal["refresh", "verify_email"],
+) -> str:
+    """
+    Map an HTTPException from decode_token to a typed security audit event name.
+
+    Call sites should catch only the decode_token failure, log this event, then re-raise.
+    """
+    detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+
+    if detail == "Token has expired":
+        kind = "expired"
+    elif "Missing required claims" in detail:
+        kind = "missing_claim"
+    else:
+        kind = "decode"
+
+    if flow == "refresh":
+        return {
+            "expired": "refresh_token_expired",
+            "missing_claim": "refresh_token_missing_claim",
+            "decode": "refresh_token_decode_error",
+        }[kind]
+
+    return {
+        "expired": "verify_email_token_invalid_expired",
+        "missing_claim": "verify_email_token_invalid_missing_claim",
+        "decode": "verify_email_token_invalid_decode",
+    }[kind]
+
+
 def validate_token_claims(payload: dict) -> None:
     """Verify required token claims and values."""
     required_claims = {"sub", "iat", "exp", "iss", "aud", "type", "jti", "nbf"}

--- a/backend/test/integration/test_api_auth_comprehensive.py
+++ b/backend/test/integration/test_api_auth_comprehensive.py
@@ -482,6 +482,31 @@ class TestAuthenticationEdgeCases:
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     @pytest.mark.asyncio
+    async def test_verify_email_expired_emits_typed_security_event(self, client: AsyncClient) -> None:
+        """Expired verification JWT should emit verify_email_token_invalid_expired."""
+        from fastapi import BackgroundTasks
+
+        _, headers = await get_csrf_token(client)
+        with patch("app.core.security.decode_token") as mock_decode:
+            mock_decode.side_effect = HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has expired"
+            )
+            with patch.object(BackgroundTasks, "add_task") as mock_add_task:
+                response = await client.post(
+                    f"{settings.API_V1_STR}/auth/verify-email",
+                    json={"token": "expired.verification.token"},
+                    headers=headers,
+                )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        event_types = [
+            call.kwargs.get("event_type")
+            for call in mock_add_task.call_args_list
+            if call.kwargs.get("event_type")
+        ]
+        assert "verify_email_token_invalid_expired" in event_types
+
+    @pytest.mark.asyncio
     async def test_refresh_token_with_invalid_token(self, client: AsyncClient) -> None:
         """Test token refresh with invalid refresh token."""
 
@@ -490,6 +515,29 @@ class TestAuthenticationEdgeCases:
         )
 
         assert response.status_code in [400, 401, 403, 422]
+
+    @pytest.mark.asyncio
+    async def test_refresh_token_expired_emits_typed_security_event(self, client: AsyncClient) -> None:
+        """Expired refresh JWT should emit refresh_token_expired audit event."""
+        from fastapi import BackgroundTasks
+
+        with patch("app.api.v1.endpoints.auth.decode_token") as mock_decode:
+            mock_decode.side_effect = HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has expired"
+            )
+            with patch.object(BackgroundTasks, "add_task") as mock_add_task:
+                response = await client.post(
+                    f"{settings.API_V1_STR}/auth/new_access_token",
+                    json={"refresh_token": "expired.refresh.token"},
+                )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        event_types = [
+            call.kwargs.get("event_type")
+            for call in mock_add_task.call_args_list
+            if call.kwargs.get("event_type")
+        ]
+        assert "refresh_token_expired" in event_types
 
     @pytest.mark.asyncio
     async def test_change_password_with_weak_password(

--- a/backend/test/unit/test_security.py
+++ b/backend/test/unit/test_security.py
@@ -1,11 +1,19 @@
 from datetime import timedelta
+from typing import Literal
 
 import jwt
 import pytest
+from fastapi import HTTPException, status
 from jwt.exceptions import ExpiredSignatureError
 
 from app.core.config import settings
-from app.core.security import PasswordValidator, create_access_token, create_refresh_token, decode_token
+from app.core.security import (
+    PasswordValidator,
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    map_jwt_http_error_to_event,
+)
 
 
 def test_password_hashing() -> None:
@@ -120,3 +128,30 @@ def test_decode_token() -> None:
 
     # Check if the token is decoded correctly
     assert decoded["sub"] == user_id
+
+
+@pytest.mark.parametrize(
+    ("detail", "flow", "expected"),
+    [
+        ("Token has expired", "refresh", "refresh_token_expired"),
+        ("Missing required claims: {'sub'}", "refresh", "refresh_token_missing_claim"),
+        ("Invalid token format", "refresh", "refresh_token_decode_error"),
+        ("Invalid token", "refresh", "refresh_token_decode_error"),
+        ("Invalid token audience", "refresh", "refresh_token_decode_error"),
+        ("Token has expired", "verify_email", "verify_email_token_invalid_expired"),
+        (
+            "Missing required claims: {'jti'}",
+            "verify_email",
+            "verify_email_token_invalid_missing_claim",
+        ),
+        ("Invalid token format", "verify_email", "verify_email_token_invalid_decode"),
+        ("Invalid token", "verify_email", "verify_email_token_invalid_decode"),
+        ("Token not yet valid", "verify_email", "verify_email_token_invalid_decode"),
+    ],
+)
+def test_map_jwt_http_error_to_event(
+    detail: str, flow: Literal["refresh", "verify_email"], expected: str
+) -> None:
+    """Map decode_token HTTPException details to typed security audit event names."""
+    exc = HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=detail)
+    assert map_jwt_http_error_to_event(exc, flow=flow) == expected


### PR DESCRIPTION
## Summary
- Add `map_jwt_http_error_to_event` to map `decode_token` HTTPException details to typed audit event names
- Re-emit refresh (`refresh_token_expired` / `_decode_error` / `_missing_claim`) and verify-email (`verify_email_token_invalid_*`) events without restoring PyJWT exception trees at call sites
- Keep existing logout/success event types and HTTP status/body contracts unchanged

## Test plan
- [x] Unit tests for `map_jwt_http_error_to_event` (expired / missing-claim / decode for both flows)
- [x] Integration: refresh expired JWT emits `refresh_token_expired`
- [x] Integration: verify-email expired JWT emits `verify_email_token_invalid_expired`
- [x] mypy on touched modules
- [x] CI full suite

Fixes #71