### PR TITLE
🛠️ fix(.github): allow graphify workflow to create maintenance PRs

### DIFF
--- a/.github/workflows/graphify-report.yml
+++ b/.github/workflows/graphify-report.yml
@@ -28,6 +28,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: main
+          # Prefer GRAPHIFY_PR_TOKEN when set so PR creation works even if the
+          # repo setting "Allow GitHub Actions to create and approve pull
+          # requests" is off. Falls back to GITHUB_TOKEN.
+          token: ${{ secrets.GRAPHIFY_PR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -44,7 +48,7 @@ jobs:
 
       - name: Create or update maintenance PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GRAPHIFY_PR_TOKEN || secrets.GITHUB_TOKEN }}
           BRANCH: chore/graphify-report
           PR_TITLE: "📝 docs(graphify-out): refresh GRAPH_REPORT.md"
           PR_BODY: |
@@ -63,6 +67,7 @@ jobs:
 
             - [ ] Skim `GRAPH_REPORT.md` for obvious nonsense after large refactors
             - [ ] Confirm diff touches only `graphify-out/GRAPH_REPORT.md`
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
@@ -82,11 +87,18 @@ jobs:
           git push -u origin "HEAD:$BRANCH" --force
 
           OPEN_COUNT="$(gh pr list --head "$BRANCH" --base main --state open --json number --jq 'length')"
-          if [ "$OPEN_COUNT" = "0" ]; then
-            gh pr create --base main --head "$BRANCH" \
-              --title "$PR_TITLE" \
-              --body "$PR_BODY"
-            echo "Opened new maintenance PR for $BRANCH"
-          else
+          if [ "$OPEN_COUNT" != "0" ]; then
             echo "Updated existing open PR for $BRANCH"
+            exit 0
           fi
+
+          if gh pr create --base main --head "$BRANCH" \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY"; then
+            echo "Opened new maintenance PR for $BRANCH"
+            exit 0
+          fi
+
+          echo "::error::Failed to create pull request. Branch was pushed: https://github.com/${REPO}/compare/main...${BRANCH}"
+          echo "::error::Enable Settings → Actions → General → Workflow permissions → 'Allow GitHub Actions to create and approve pull requests', or add a classic/fine-grained PAT as secret GRAPHIFY_PR_TOKEN (contents + pull requests)."
+          exit 1

--- a/docs/agents/graphify.md
+++ b/docs/agents/graphify.md
@@ -163,6 +163,15 @@ Behavior:
 
 This job is **not** a required status check and must not block feature PRs.
 
+### Repo setup (required for PR creation)
+
+`GITHUB_TOKEN` can push the maintenance branch, but creating the PR needs one of:
+
+1. **Preferred:** Settings → Actions → General → Workflow permissions → enable **Allow GitHub Actions to create and approve pull requests**, or
+2. Add a PAT (contents + pull requests) as repository secret `GRAPHIFY_PR_TOKEN`.
+
+Without one of those, the workflow refreshes and pushes `chore/graphify-report` but fails at `gh pr create`.
+
 Design notes: [`docs/research/graphify-automation.md`](../research/graphify-automation.md).
 
 ### Optional local hooks


### PR DESCRIPTION
## Summary
- The weekly graphify workflow pushed `chore/graphify-report` but failed at `gh pr create` because `GITHUB_TOKEN` cannot open PRs unless the repo allows it.
- Prefer optional `GRAPHIFY_PR_TOKEN`, keep a clearer `::error` with the compare URL, and document the required Actions setting in `docs/agents/graphify.md`.

Related: maintenance report PR https://github.com/mnaimfaizy/fastapi_rbac/pull/87

## Test plan
- [x] Enable **Allow GitHub Actions to create and approve pull requests** (or set `GRAPHIFY_PR_TOKEN`)
- [x] Re-run **Refresh graphify report** and confirm it can open/update the maintenance PR
- [x] Confirm error message is actionable if the setting/secret is still missing

Made with [Cursor](https://cursor.com)