### PR TITLE
📝 docs(graphify-out): refresh GRAPH_REPORT.md

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -9,7 +9,7 @@
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `1de8ad55`
+- Built from commit: `5a6f9362`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 


### PR DESCRIPTION
## Summary

Automated full-repo code-only graphify rebuild (`extract --code-only` + `cluster-only --no-label`).

- Updates only `graphify-out/GRAPH_REPORT.md`
- Does not change runtime application behavior
- Heavy artifacts (`graph.json`, etc.) remain gitignored

Triggered by weekly schedule or manual `workflow_dispatch`.
See `docs/agents/graphify.md` and `docs/research/graphify-automation.md`.

## Test plan

- [x] Skim `GRAPH_REPORT.md` for obvious nonsense after large refactors
- [x] Confirm diff touches only `graphify-out/GRAPH_REPORT.md`
