### PR TITLE
docs: commit-message SSOT and scrub stale CHANGELOG refs

### DIFF
--- a/.changelogrc.md
+++ b/.changelogrc.md
@@ -2,135 +2,49 @@
 
 ## Overview
 
-This file defines how changelogs are generated from Git commit history.
-It uses conventional commit messages to categorize changes.
+This file defines how **release notes are categorized** from Git commit history and how SemVer bumps relate to commit types.
 
-## Conventional Commit Format
+- **Commit message format (SSOT):** [`docs/agents/commit-messages.md`](docs/agents/commit-messages.md) — follow that file for type, scope, emoji policy, and breaking-change syntax. Do not redefine divergent format rules here.
+- **Committed release history (SSOT):** [`docs/release-notes.md`](docs/release-notes.md). There is **no** root `CHANGELOG.md` in this repository.
+- **Ephemeral draft:** `changelog.txt` (gitignored) may be generated from `git log` during a release; merge curated bullets into `docs/release-notes.md`.
 
-All commits should follow the format:
-```
-<type>(<scope>): <subject>
+## Type → release-notes sections
 
-[optional body]
+Types below are included when drafting release notes (full format rules: `docs/agents/commit-messages.md`):
 
-[optional footer]
-```
+- **feat**: New Features
+- **fix**: Bug Fixes
+- **perf**: Performance
+- **security**: Security
+- **docs**: Documentation
+- **refactor**: Code Improvements / Technical Details
+- **test**: Testing / Technical Details
+- **build**: Build System / Technical Details
+- **ci**: CI/CD / Technical Details
+- **chore**: Maintenance (often omit if internal-only)
 
-### Commit Types
+`style` and most pure `chore` commits are usually omitted from user-facing notes. Breaking changes (`!` or `BREAKING CHANGE:` footer) always go under **Breaking Changes**.
 
-The following commit types will be included in changelogs:
+## Scope reminders
 
-- **feat**: New features (appears in "New Features" section)
-- **fix**: Bug fixes (appears in "Bug Fixes" section)
-- **perf**: Performance improvements (appears in "Performance" section)
-- **security**: Security enhancements (appears in "Security" section)
-- **docs**: Documentation changes (appears in "Documentation" section)
-- **refactor**: Code refactoring (appears in "Code Improvements" section)
-- **test**: Test additions or improvements (appears in "Testing" section)
-- **build**: Build system changes (appears in "Build System" section)
-- **ci**: CI/CD changes (appears in "CI/CD" section)
-- **chore**: Maintenance tasks (appears in "Maintenance" section)
+Use component/domain scopes from the commit-message SSOT (`auth`, `api`, `ui`, `docker`, `ci`, …). Examples of good commits:
 
-### Breaking Changes
-
-Breaking changes should be indicated with:
-- `BREAKING CHANGE:` in the commit footer, or
-- `!` after the type/scope (e.g., `feat!:` or `feat(api)!:`)
-
-These will appear in a "Breaking Changes" section with high visibility.
-
-## Scope Guidelines
-
-Recommended scopes by component:
-
-### Backend
-- `api`: API endpoints and routes
-- `auth`: Authentication and authorization
-- `db`: Database models and migrations
-- `crud`: CRUD operations
-- `deps`: Dependency management
-- `config`: Configuration management
-- `worker`: Celery worker tasks
-- `email`: Email functionality
-- `security`: Security features
-
-### Frontend
-- `ui`: User interface components
-- `auth`: Authentication flows
-- `api`: API service calls
-- `state`: Redux state management
-- `types`: TypeScript types
-- `routing`: React Router configuration
-- `forms`: Form components
-- `components`: Reusable components
-
-### Infrastructure
-- `docker`: Docker configuration
-- `ci`: CI/CD workflows
-- `deploy`: Deployment scripts
-- `docs`: Documentation
-- `release`: Release process
-
-## Examples
-
-### Feature Addition
 ```
 feat(auth): add two-factor authentication support
-
-Implemented TOTP-based 2FA for enhanced security.
-Users can now enable 2FA in their profile settings.
-
-Closes #123
-```
-
-### Bug Fix
-```
 fix(api): resolve rate limiting bypass vulnerability
-
-Fixed issue where rate limiting could be bypassed
-by using different case variations of email addresses.
-
-Fixes #456
-```
-
-### Breaking Change
-```
 feat(api)!: redesign authentication API endpoints
-
-BREAKING CHANGE: Authentication endpoints have been restructured.
-- Renamed /auth/login to /auth/token
-- Changed response format for /auth/user endpoint
-- Removed deprecated /auth/legacy endpoint
-
-Migration guide: docs/migration-v2.md
-```
-
-### Performance Improvement
-```
 perf(db): optimize user query with eager loading
-
-Reduced N+1 queries by implementing eager loading
-for user roles and permissions. Query time reduced
-from ~500ms to ~50ms for typical user fetch.
-```
-
-### Documentation
-```
 docs(api): add comprehensive API endpoint documentation
-
-- Added OpenAPI descriptions for all endpoints
-- Included example requests and responses
-- Documented error codes and edge cases
 ```
 
 ## Changelog Generation
 
-### Automated Generation
+### Automated draft (ephemeral)
 
-The release script automatically generates changelogs:
+The release script generates a temporary draft from Git history:
 
 ```bash
-# Generate changelog from last tag to HEAD
+# Generate draft between tags (gitignored; not the SSOT)
 git log <last-tag>..HEAD --pretty=format:"- %s" > changelog.txt
 ```
 
@@ -138,10 +52,10 @@ git log <last-tag>..HEAD --pretty=format:"- %s" > changelog.txt
 
 After generation, manually review and categorize commits:
 
-1. Copy raw changelog to appropriate sections in `docs/release-notes.md`
+1. Copy curated bullets into appropriate sections in `docs/release-notes.md`
 2. Organize by type (New Features, Bug Fixes, etc.)
 3. Add context and user-facing descriptions
-4. Remove internal/chore commits if not relevant to users
+4. Remove internal/`chore`/`style` commits if not relevant to users
 5. Highlight breaking changes prominently
 
 ## Release Notes Template
@@ -181,13 +95,13 @@ After generation, manually review and categorize commits:
 
 ### Commit Message Guidelines
 
-1. **Use present tense**: "Add feature" not "Added feature"
-2. **Use imperative mood**: "Fix bug" not "Fixes bug"
-3. **Be specific**: "Fix login rate limiting" not "Fix bug"
-4. **Reference issues**: Include issue numbers when applicable
-5. **Keep subject short**: Under 72 characters
-6. **Add body for complex changes**: Explain what and why
-7. **Use footer for metadata**: Breaking changes, issue references
+Follow [`docs/agents/commit-messages.md`](docs/agents/commit-messages.md). Short reminders:
+
+1. **Use present tense / imperative mood**: "Add feature" not "Added feature"
+2. **Be specific**: "Fix login rate limiting" not "Fix bug"
+3. **Reference issues**: `Fixes #123` / `Closes #456` in the footer when applicable
+4. **Keep subject short**: Under 72 characters
+5. **No emoji** in commit subjects
 
 ### Changelog Guidelines
 
@@ -198,6 +112,7 @@ After generation, manually review and categorize commits:
 5. **Searchable**: Use consistent terminology
 6. **Versioned**: Always associate with a specific version
 7. **Dated**: Include release date in ISO format (YYYY-MM-DD)
+8. **SSOT**: Publish only in `docs/release-notes.md` (not a root `CHANGELOG.md`)
 
 ### Version Bumping Rules
 
@@ -205,16 +120,18 @@ Based on Semantic Versioning:
 
 - **Patch** (0.0.X): Bug fixes, minor improvements
   - Examples: `fix:`, `perf:`, `docs:`
-  
+
 - **Minor** (0.X.0): New features, backward-compatible
   - Examples: `feat:` without breaking changes
-  
+
 - **Major** (X.0.0): Breaking changes, major rewrites
   - Examples: `feat!:`, `BREAKING CHANGE:` in footer
 
 ## Tools and Automation
 
-### Recommended Tools
+### Recommended Tools (optional)
+
+These tools are **not** required by this repo. If you use them elsewhere, note that many default to writing a root `CHANGELOG.md`. **This project does not maintain `CHANGELOG.md`**; curated history belongs in `docs/release-notes.md`.
 
 1. **commitizen**: Interactive commit message creation
    ```bash
@@ -222,28 +139,27 @@ Based on Semantic Versioning:
    git cz
    ```
 
-2. **conventional-changelog**: Automated changelog generation
+2. **conventional-changelog** (hypothetical / other projects):
    ```bash
+   # Third-party default often targets CHANGELOG.md — do not adopt that path here.
+   # Prefer: git log draft → edit → docs/release-notes.md
    npm install -g conventional-changelog-cli
-   conventional-changelog -p angular -i CHANGELOG.md -s
+   # Example only (not repo practice): conventional-changelog -p angular -i CHANGELOG.md -s
    ```
 
-3. **standard-version**: Automated versioning and changelog
-   ```bash
-   npm install -g standard-version
-   standard-version
-   ```
+3. **standard-version** (hypothetical / other projects): also defaults to `CHANGELOG.md`; this repo uses release scripts + `docs/release-notes.md` instead.
 
 ### Git Hooks
 
-Consider adding a commit-msg hook to validate format:
+Commit-msg / commitlint enforcement is a deferred follow-up. Until then, agents and humans must still follow `docs/agents/commit-messages.md`. Example hook (optional local experiment):
 
 ```bash
 #!/bin/sh
 # .git/hooks/commit-msg
 
-if ! grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: .+' "$1"; then
+if ! grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|security)(\(.+\))?\!?: .+' "$1"; then
     echo "Commit message does not follow conventional format"
+    echo "See docs/agents/commit-messages.md"
     echo "Format: <type>(<scope>): <subject>"
     exit 1
 fi
@@ -251,7 +167,9 @@ fi
 
 ## References
 
+- [Commit messages SSOT](docs/agents/commit-messages.md)
+- [Release notes SSOT](docs/release-notes.md)
 - [Conventional Commits](https://www.conventionalcommits.org/)
 - [Semantic Versioning](https://semver.org/)
-- [Keep a Changelog](https://keepachangelog.com/)
+- [Keep a Changelog](https://keepachangelog.com/) (external format inspiration; this repo uses `docs/release-notes.md`)
 - [Angular Commit Guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,8 +18,11 @@ This project is a user-management microservice: FastAPI backend + React/TypeScri
 | Testing | [`docs/development/TESTING.md`](../docs/development/TESTING.md), [`docs/frontend/react/testing.md`](../docs/frontend/react/testing.md), [`backend/test/README.md`](../backend/test/README.md) |
 | Frontend troubleshooting | [`docs/troubleshooting/frontend-issues.md`](../docs/troubleshooting/frontend-issues.md) |
 | Knowledge graph | [`docs/agents/graphify.md`](../docs/agents/graphify.md) |
+| Commit messages (mandatory SSOT) | [`docs/agents/commit-messages.md`](../docs/agents/commit-messages.md) |
 
 If `graphify-out/graph.json` exists, prefer `graphify query` / `path` / `explain` for “how does X connect to Y” questions.
+
+**Commit messages are mandatory:** follow [`docs/agents/commit-messages.md`](../docs/agents/commit-messages.md) strictly (plain conventional commits, no emoji, component/domain scopes). Do not invent alternate formats.
 
 ## Coding constraints
 

--- a/.github/instructions/pre-commit.instructions.md
+++ b/.github/instructions/pre-commit.instructions.md
@@ -14,8 +14,9 @@ When performing a commit in this project, always follow this workflow:
 
 2. **Commit Message**
 
-   - Use the commit message format and rules from the commit prompt (which will be provided at commit time).
-   - Ensure the commit message follows the Angular standard with emojis and correct scope.
+   - Follow [`docs/agents/commit-messages.md`](../../docs/agents/commit-messages.md) **strictly** (mandatory SSOT).
+   - Format: `<type>(<scope>): <subject>` — no emoji; component/domain scopes.
+   - The `/commit` prompt (`.github/prompts/commit.prompt.md`) also points at that SSOT.
 
 3. **Pre-commit Hook Enforcement**
 
@@ -38,6 +39,6 @@ When performing a commit in this project, always follow this workflow:
 
 **Summary:**
 
-- Always stage, check, and commit using the provided commit prompt.
+- Always stage, check, and commit using the canonical commit-message SSOT.
 - Strictly follow and resolve all pre-commit hook issues before completing the commit.
 - Repeat as needed until the commit is successful and clean.

--- a/.github/prompts/commit.prompt.md
+++ b/.github/prompts/commit.prompt.md
@@ -10,7 +10,7 @@ When the `/commit` command is invoked in chat, the agent must:
 2. Immediately begin the commit workflow:
    - Check git status.
    - Stage all relevant changes.
-   - Prompt for or generate a commit message following the rules below.
+   - Prompt for or generate a commit message following **`docs/agents/commit-messages.md`** (mandatory SSOT).
    - Run pre-commit hooks and resolve any issues.
    - Repeat as needed until the commit is successful and clean.
 3. Do NOT simply acknowledge these instructions—always proceed with the commit process.
@@ -19,66 +19,24 @@ This ensures that including `/commit` in chat will always trigger the full commi
 
 # Commit Message Instructions for Agents and LLMs
 
-When making commits in this project, always follow these rules:
+**Follow [`docs/agents/commit-messages.md`](../../docs/agents/commit-messages.md) strictly.** Do not invent alternate formats.
 
-## 1. Use Angular Commit Message Standards with Emojis
+Summary (full rules live in the SSOT):
 
-- Start every commit message with a relevant emoji.
-- Use the Angular commit type (feat, fix, chore, docs, refactor, test, perf, ci, build, style, etc.).
-- If the change is in a specific directory (e.g., backend, react-frontend, docs, scripts), include the directory in parentheses after the type.
-- For root-level or global changes (e.g., .github, LICENSE, README.md), use the directory or file name in parentheses.
+- Format: `<type>(<scope>): <subject>`
+- **No emoji**
+- Component/domain scopes (`auth`, `api`, `ui`, `docker`, `ci`, …) — not top-level directory names
+- Imperative mood; breaking changes use `!` and/or `BREAKING CHANGE:` footer
 
 ### Examples
 
-- For root-level or global changes:
-
-  - 🛠️ chore(github): update GitHub Actions workflow for CI
-  - 📄 docs(README): update project overview and usage instructions
-  - 📝 chore(LICENSE): update copyright
-
-- For changes in subdirectories:
-  - 🐍 fix(backend): correct user role assignment logic
-  - ⚛️ feat(react-frontend): add user profile page
-  - 📝 docs(docs): add API usage section to documentation
-  - 🛠️ chore(scripts): update deployment script for production
-
-## 2. Commit Message Structure
-
-- **Title:**
-  `<emoji> <type>(<scope>): <short summary>`
-- **Body (optional):**
-  Add a longer description if needed, explaining what and why.
-
-## 3. Scopes
-
-- Use the directory or file name as the scope, e.g.:
-  - backend
-  - react-frontend
-  - docs
-  - scripts
-  - .github
-  - LICENSE
-  - README
-
-## 4. Best Practices
-
-- Be concise and clear.
-- Use imperative mood (“add”, “fix”, “update”, not “added”, “fixed”, “updated”).
-- Always include an emoji at the start.
-- If multiple directories are affected, use a general scope or list the main ones.
+```
+feat(auth): add two-factor authentication support
+fix(api): resolve rate limiting bypass vulnerability
+docs(release): update release notes for v1.2.3
+chore(ci): update GitHub Actions workflow for CI
+```
 
 ---
 
-**Example Commit Messages:**
-
-- 🐛 fix(backend): resolve permission deletion bug in API
-- ✨ feat(react-frontend): implement dark mode toggle
-- 📝 docs(docs): add troubleshooting guide for Docker Compose
-- 🛠️ chore(scripts): update test runner for new test structure
-- 📄 docs(README): clarify environment setup instructions
-- 🧹 chore(.github): update issue templates
-
----
-
-**Summary:**
-Always use Angular commit standards with emojis, specify the directory or file in the scope, and write clear, concise messages. This ensures easy release note generation and maintainable commit history.
+**Summary:** Always use the canonical commit-message SSOT. That keeps history consistent for automated release notes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,10 @@ System architecture, directory layout, domain model overview, and Redis allowlis
 
 If `graphify-out/graph.json` exists, **query it first** for architecture and module-relationship questions (`graphify query` / `path` / `explain`). Build and update instructions: `docs/agents/graphify.md`. `GRAPH_REPORT.md` is committed; heavy artifacts are gitignored and rebuilt locally.
 
+### Commit messages (mandatory)
+
+Commit messages must follow [`docs/agents/commit-messages.md`](docs/agents/commit-messages.md). This is not optional: plain conventional commits, no emoji, component/domain scopes. Release-note generation depends on consistent history.
+
 ## Notes
 
 - Canonical skill location is `.claude/skills`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,10 +34,15 @@ System architecture and auth-flow narrative: `docs/reference/architecture.md`. H
 
 If `graphify-out/graph.json` exists, query it first for architecture questions. See `docs/agents/graphify.md` for install, build (`--code-only`), update, and git policy.
 
+### Commit messages (mandatory)
+
+Commit messages must follow [`docs/agents/commit-messages.md`](docs/agents/commit-messages.md). This is not optional: plain conventional commits, no emoji, component/domain scopes.
+
 ## Project conventions
 
 When working in this repository, follow conventions in:
 
 - `.github/copilot-instructions.md`
+- `docs/agents/commit-messages.md` (commit message SSOT)
 - `.github/instructions/pre-commit.instructions.md`
 - `.github/instructions/resolve-issue.instructions.md`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ This document describes the complete release process for the FastAPI RBAC projec
 - [Release Process](#release-process)
 - [Automated Release Workflow](#automated-release-workflow)
 - [Multi-Architecture Support](#multi-architecture-support)
-- [Changelog Management](#changelog-management)
+- [Release Notes Management](#release-notes-management)
 - [Rollback Procedures](#rollback-procedures)
 - [Security Considerations](#security-considerations)
 - [Troubleshooting](#troubleshooting)
@@ -35,6 +35,8 @@ FastAPI RBAC uses a fully automated CI/CD pipeline for releases:
 5. **Security**: Secure handling of credentials and secrets
 6. **Rollback Ready**: Easy rollback to previous versions
 
+**Release history SSOT:** [`docs/release-notes.md`](docs/release-notes.md). There is no root `CHANGELOG.md`. Docker Hub repository descriptions come from `*.dockerhub.md` files (see workflow step 9 below), not from release notes.
+
 ## Versioning Strategy
 
 We follow [Semantic Versioning 2.0.0](https://semver.org/):
@@ -46,7 +48,7 @@ MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
 ### Version Format
 
 - **Stable Releases**: `vMAJOR.MINOR.PATCH` (e.g., `v1.2.3`)
-- **Pre-releases**: 
+- **Pre-releases**:
   - Alpha: `vMAJOR.MINOR.PATCH-alpha.N` (e.g., `v1.0.0-alpha.1`)
   - Beta: `vMAJOR.MINOR.PATCH-beta.N` (e.g., `v1.0.0-beta.2`)
   - Release Candidate: `vMAJOR.MINOR.PATCH-rc.N` (e.g., `v1.0.0-rc.1`)
@@ -133,8 +135,7 @@ Before creating a release, ensure:
 ### Version and Documentation
 
 - [ ] Version number decided and validated
-- [ ] CHANGELOG.md updated with all changes
-- [ ] Release notes prepared in docs/release-notes.md
+- [ ] Release notes prepared in `docs/release-notes.md` (release history SSOT)
 - [ ] README.md updated if needed
 - [ ] API documentation updated
 
@@ -222,7 +223,7 @@ Edit `docs/release-notes.md`:
 
 ```bash
 git add docs/release-notes.md
-git commit -m "docs: update release notes for v1.2.3"
+git commit -m "docs(release): update release notes for v1.2.3"
 git push origin main
 ```
 
@@ -280,11 +281,15 @@ The `docker-publish.yml` workflow triggers on:
 5. Determine version tag
 6. Build Docker images:
    - Backend (FastAPI app)
-   - Frontend (React app) 
+   - Frontend (React app)
    - Worker (Celery worker)
 7. Tag images with version
 8. Push to Docker Hub
-9. Update Docker Hub descriptions
+9. Update Docker Hub descriptions from:
+   - `backend/README.dockerhub.md`
+   - `react-frontend/README.dockerhub.md`
+   - `backend/README.worker.dockerhub.md`
+   (via `.github/workflows/docker-publish.yml` — not from `docs/release-notes.md`)
 ```
 
 ### Multi-Architecture Builds
@@ -346,34 +351,38 @@ docker buildx build --platform linux/amd64 ...
 docker buildx build --platform linux/arm64 ...
 ```
 
-## Changelog Management
+## Release Notes Management
 
-### Automated Changelog Generation
+**SSOT:** [`docs/release-notes.md`](docs/release-notes.md). Ephemeral `changelog.txt` is a gitignored draft only. This repo does not maintain a root `CHANGELOG.md`.
 
-The release script generates changelogs from Git commit history:
+### Automated Draft Generation
+
+The release script generates a temporary draft from Git commit history:
 
 ```bash
-# Generate changelog between tags
+# Generate draft between tags (merge curated bullets into docs/release-notes.md)
 git log v1.2.2..HEAD --pretty=format:"- %s" > changelog.txt
 ```
 
 ### Conventional Commits
 
-Use conventional commit format for better changelog generation:
+Commit messages must follow [`docs/agents/commit-messages.md`](docs/agents/commit-messages.md) (mandatory SSOT: plain conventional commits, no emoji, component scopes). Examples:
 
 ```
-feat: add user profile feature
-fix: resolve authentication bug
-docs: update API documentation
-chore: update dependencies
-test: add integration tests
-refactor: improve code structure
-perf: optimize database queries
+feat(auth): add user profile feature
+fix(api): resolve authentication bug
+docs(api): update API documentation
+chore(deps): update dependencies
+test(auth): add integration tests
+refactor(crud): improve code structure
+perf(db): optimize database queries
 ```
+
+Type → section mapping for release notes: see the commit-message SSOT and [`.changelogrc.md`](.changelogrc.md).
 
 ### Categorizing Changes
 
-Organize changes into categories:
+Organize changes into categories in `docs/release-notes.md`:
 
 - **New Features**: New functionality added
 - **Bug Fixes**: Bugs and issues resolved
@@ -429,7 +438,7 @@ git push origin :refs/tags/v1.2.3
 
 ```bash
 # Fix issues
-git commit -m "fix: resolve issue from v1.2.3"
+git commit -m "fix(api): resolve issue from v1.2.3"
 
 # Create new patch version
 ./scripts/deployment/release/create-release.sh -v v1.2.4
@@ -444,7 +453,7 @@ For critical bugs requiring immediate fix:
 git checkout -b hotfix/v1.2.4 v1.2.3
 
 # Apply fix
-git commit -m "fix: critical security vulnerability"
+git commit -m "fix(security): critical security vulnerability"
 
 # Merge to main
 git checkout main
@@ -588,27 +597,27 @@ If you encounter issues not covered here:
 
 ### Before Every Release
 
-✅ Run full test suite  
-✅ Update documentation  
-✅ Review and update changelog  
-✅ Test in staging environment  
-✅ Verify all CI checks pass  
+✅ Run full test suite
+✅ Update documentation
+✅ Review and update `docs/release-notes.md`
+✅ Test in staging environment
+✅ Verify all CI checks pass
 
 ### During Release
 
-✅ Use automation scripts when possible  
-✅ Test with dry-run first  
-✅ Monitor CI/CD workflow  
-✅ Verify images on Docker Hub  
-✅ Test deployed images  
+✅ Use automation scripts when possible
+✅ Test with dry-run first
+✅ Monitor CI/CD workflow
+✅ Verify images on Docker Hub
+✅ Test deployed images
 
 ### After Release
 
-✅ Announce release to team/users  
-✅ Monitor for issues  
-✅ Update production deployments  
-✅ Archive release artifacts  
-✅ Plan next release cycle  
+✅ Announce release to team/users
+✅ Monitor for issues
+✅ Update production deployments
+✅ Archive release artifacts
+✅ Plan next release cycle
 
 ## Quick Reference
 

--- a/docs/agents/commit-messages.md
+++ b/docs/agents/commit-messages.md
@@ -1,0 +1,165 @@
+# Commit Messages (canonical)
+
+**This file is the single source of truth for commit message format in this repository.**
+
+Agents and humans must follow these rules strictly. Do not invent alternate formats from other harness files, user preferences, or prior habit. Harness files (Cursor rules, Copilot prompts, Claude skills, pre-commit instructions) link here; they must not redefine divergent rules.
+
+Release history is written to [`docs/release-notes.md`](../release-notes.md). Commit types below map to those sections so a release-notes agent can categorize commits reliably. Changelog tooling notes live in [`.changelogrc.md`](../../.changelogrc.md).
+
+## Format
+
+```
+<type>(<scope>): <subject>
+
+[optional body]
+
+[optional footer]
+```
+
+- Imperative mood: "add", "fix", "update" — not "added", "fixed", "updated"
+- Subject ~50–72 characters; no trailing period
+- Body explains what and why when the change is non-obvious
+- One logical change per commit when practical
+
+## Emoji policy
+
+**Forbidden.** Do not put emoji in the commit subject or as a prefix.
+
+Correct: `feat(auth): add two-factor authentication`
+
+Incorrect: `✨ feat(auth): add two-factor authentication`
+
+## Types
+
+| Type | Use for | In release notes? | Release-notes section |
+| --- | --- | --- | --- |
+| `feat` | New user-facing or API capability | Yes | New Features |
+| `fix` | Bug fix | Yes | Bug Fixes |
+| `perf` | Performance improvement | Yes | Performance |
+| `security` | Security fix or hardening | Yes | Security |
+| `docs` | Documentation only | Often | Documentation |
+| `refactor` | Internal restructuring, no behavior change | Sometimes | Code Improvements / Technical Details |
+| `test` | Tests only | Rarely | Testing / Technical Details |
+| `build` | Build system, packaging, dependencies tooling | Rarely | Build System / Technical Details |
+| `ci` | CI/CD workflows and config | Rarely | CI/CD / Technical Details |
+| `chore` | Maintenance that does not fit above | Rarely | Maintenance / omit if internal-only |
+| `style` | Formatting, whitespace, lint-only (no logic) | No | — (omit from user-facing notes) |
+| `revert` | Revert a previous commit | Yes if user-facing | Match the reverted change’s section |
+
+Breaking changes always surface under **Breaking Changes** in release notes regardless of type (see below).
+
+## Scopes (component / domain)
+
+Use a **component or domain** scope, not a top-level directory name (`backend`, `react-frontend`). Prefer the lists below; omit scope only when the change is truly repo-wide and no component fits.
+
+### Backend
+
+- `api` — API endpoints and routes
+- `auth` — Authentication and authorization
+- `db` — Database models and migrations
+- `crud` — CRUD operations
+- `deps` — Dependency injection / deps layer
+- `config` — Configuration
+- `worker` — Celery worker tasks
+- `email` — Email functionality
+- `security` — Security features
+
+### Frontend
+
+- `ui` — User interface components
+- `auth` — Authentication flows
+- `api` — API service calls
+- `state` — Redux / client state
+- `types` — TypeScript types
+- `routing` — React Router
+- `forms` — Form components
+- `components` — Shared reusable components
+
+### Infrastructure
+
+- `docker` — Docker configuration
+- `ci` — CI/CD workflows
+- `deploy` — Deployment scripts
+- `docs` — Documentation site / agent docs
+- `release` — Release process
+
+## Breaking changes
+
+Indicate with either:
+
+- `!` after the type or scope: `feat!:` or `feat(api)!:`
+- and/or a footer line starting with `BREAKING CHANGE:`
+
+These map to the **Breaking Changes** section in `docs/release-notes.md` and imply a major SemVer bump.
+
+## Issue footers
+
+When a commit resolves an issue:
+
+```
+Fixes #123
+```
+
+or
+
+```
+Closes #456
+```
+
+## Examples
+
+```
+feat(auth): add two-factor authentication support
+
+Implemented TOTP-based 2FA for enhanced security.
+Users can now enable 2FA in their profile settings.
+
+Closes #123
+```
+
+```
+fix(api): resolve rate limiting bypass vulnerability
+
+Fixed issue where rate limiting could be bypassed
+by using different case variations of email addresses.
+
+Fixes #456
+```
+
+```
+feat(api)!: redesign authentication API endpoints
+
+BREAKING CHANGE: Authentication endpoints have been restructured.
+- Renamed /auth/login to /auth/token
+- Changed response format for /auth/user endpoint
+- Removed deprecated /auth/legacy endpoint
+
+Migration guide: docs/migration-v2.md
+```
+
+```
+docs(release): clarify release-notes SSOT and Hub README sources
+```
+
+## Mapping commits → release notes
+
+For drafting [`docs/release-notes.md`](../release-notes.md) from commits since the last tag:
+
+1. Parse conventional commits (`type`, optional `scope`, subject, breaking markers).
+2. Place each commit in the section from the Types table above.
+3. Promote any commit with `!` or `BREAKING CHANGE:` into **Breaking Changes**.
+4. Rewrite subjects into user-facing bullets; drop pure `chore` / `style` / internal-only items unless they matter to operators.
+5. Ephemeral `changelog.txt` from `git log` is a draft only — never a committed SSOT. There is no root `CHANGELOG.md`.
+
+SemVer bump hints (see also `.changelogrc.md`): patch for `fix`/`perf`/`docs`; minor for non-breaking `feat`; major for breaking changes.
+
+## Enforcement
+
+Format is mandatory for humans and agents. A commit-msg / commitlint hook is a deferred follow-up; lack of a hook does not make these rules optional.
+
+## Related
+
+- [`.changelogrc.md`](../../.changelogrc.md) — changelog section mapping, SemVer bump rules, tooling notes
+- [`docs/release-notes.md`](../release-notes.md) — committed release history (SSOT)
+- [Conventional Commits](https://www.conventionalcommits.org/)
+- [Semantic Versioning](https://semver.org/)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -173,18 +173,18 @@ Use descriptive branch names with prefixes:
 
 ### Commit Messages
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
+Follow the canonical rules in [`docs/agents/commit-messages.md`](agents/commit-messages.md) (mandatory for humans and agents). Summary:
+
+- Format: `<type>(<scope>): <subject>` — [Conventional Commits](https://www.conventionalcommits.org/)
+- **No emoji**
+- Component/domain scopes (`auth`, `api`, `ui`, …)
 
 ```
-type(scope): description
-
 feat(auth): add password strength validation
-fix(user): resolve email validation issue
+fix(api): resolve email validation issue
 docs(api): update authentication endpoints
-test(user): add integration tests for user creation
+test(auth): add integration tests for user creation
 ```
-
-**Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
 
 ## Code Standards
 

--- a/docs/deployment/IMPLEMENTATION_SUMMARY.md
+++ b/docs/deployment/IMPLEMENTATION_SUMMARY.md
@@ -10,7 +10,7 @@ The project needed a better release process optimized for a complete application
 
 1. Consistent versioning and tagging
 2. Automated builds and multi-arch Docker image publishing
-3. Clear changelogs and release notes
+3. Clear release notes in `docs/release-notes.md` (SSOT; no root `CHANGELOG.md`)
 4. Secure handling of secrets and credentials
 5. Easy rollback and traceability
 6. Alignment with best practices for application releases
@@ -265,7 +265,7 @@ From the original issue checklist:
   - [x] Automated versioning and tagging (VERSION file + script)
   - [x] Automated Docker multi-arch builds
   - [x] Automated publishing to Docker Hub
-  - [x] Changelog and release notes generation (guidelines)
+  - [x] Release notes generation into `docs/release-notes.md` (guidelines; ephemeral `changelog.txt` draft)
   - [x] Secure handling of secrets (documented)
   - [x] Rollback and traceability strategy
 - [x] Document the new process in the repository

--- a/docs/deployment/QUICK_RELEASE_GUIDE.md
+++ b/docs/deployment/QUICK_RELEASE_GUIDE.md
@@ -1,6 +1,8 @@
 # Quick Release Guide
 
-This is a quick reference for common release scenarios. For comprehensive documentation, see [RELEASE.md](../RELEASE.md).
+This is a quick reference for common release scenarios. For comprehensive documentation, see [RELEASE.md](../../RELEASE.md) (from repo root) or the deployment release docs.
+
+**Release history SSOT:** [`docs/release-notes.md`](../release-notes.md). There is no root `CHANGELOG.md`. Docker Hub descriptions come from `*.dockerhub.md` via `docker-publish.yml`, not from release notes.
 
 ## 🚀 Quick Start
 
@@ -125,8 +127,9 @@ After creating a release, verify:
   - `mnaimfaizy/fastapi-rbac-worker:vX.Y.Z`
 - [ ] Images support both architectures (linux/amd64, linux/arm64)
 - [ ] VERSION file updated to `X.Y.Z` (without 'v')
-- [ ] Release notes updated in `docs/release-notes.md`
+- [ ] Release notes updated in `docs/release-notes.md` (release history SSOT)
 - [ ] Git tag created and pushed
+- [ ] Docker Hub repo descriptions reflect `*.dockerhub.md` sources (updated by `docker-publish.yml`)
 
 ## 🐛 Quick Troubleshooting
 
@@ -246,7 +249,7 @@ git push origin :refs/tags/v1.2.3
 
 ## 📞 Getting Help
 
-- **Documentation**: [RELEASE.md](../RELEASE.md)
+- **Documentation**: [RELEASE.md](../../RELEASE.md)
 - **Process Changes**: [RELEASE_IMPROVEMENTS.md](docs/deployment/RELEASE_IMPROVEMENTS.md)
 - **Original Process**: [RELEASE_PROCESS.md](docs/deployment/RELEASE_PROCESS.md)
 - **Issues**: [GitHub Issues](https://github.com/mnaimfaizy/fastapi_rbac/issues)

--- a/docs/deployment/RELEASE_IMPROVEMENTS.md
+++ b/docs/deployment/RELEASE_IMPROVEMENTS.md
@@ -95,14 +95,14 @@ Automatically updated by release script:
 - ✅ Automatically synced with release
 - ✅ No version drift between components
 
-### 3. Changelog Management
+### 3. Release Notes Management
 
 #### Before (Old Process)
 ```bash
-# Manual changelog generation
+# Manual draft generation (ephemeral changelog.txt)
 git log v1.2.2..HEAD --pretty=format:"- %s" > changelog.txt
 
-# Manual categorization required
+# Manual categorization required into docs/release-notes.md
 # No convention enforcement
 # Inconsistent format
 ```
@@ -239,8 +239,8 @@ RELEASE.md (comprehensive guide)
 #### Before (Old Process)
 ```bash
 # Basic flow
-1. Generate changelog
-2. Update release notes
+1. Generate ephemeral changelog.txt draft
+2. Update docs/release-notes.md (SSOT)
 3. Create tag
 4. Push tag
 5. (Optional) Build Docker
@@ -256,9 +256,9 @@ RELEASE.md (comprehensive guide)
 ```bash
 # Enhanced flow
 1. Validate environment
-2. Generate changelog
+2. Generate ephemeral changelog.txt draft
 3. Update VERSION file
-4. Update release notes
+4. Update docs/release-notes.md (SSOT)
 5. Commit changes
 6. Create tag
 7. Push tag
@@ -339,7 +339,7 @@ When creating the next release with the new process:
 2. ✅ Test with dry-run first: `./create-release.sh -v vX.Y.Z --dry-run`
 3. ✅ Verify multi-arch images work on both platforms
 4. ✅ Check VERSION file is updated correctly
-5. ✅ Confirm changelog follows new conventions
+5. ✅ Confirm `docs/release-notes.md` follows conventions (no root `CHANGELOG.md`)
 6. ✅ Monitor GitHub Actions workflow
 7. ✅ Verify all three images (backend, frontend, worker) published
 8. ✅ Test images in staging environment

--- a/docs/deployment/RELEASE_PROCESS.md
+++ b/docs/deployment/RELEASE_PROCESS.md
@@ -10,6 +10,8 @@ This document outlines the steps to create and publish a new release for the Fas
     - `DOCKERHUB_USERNAME`: Your Docker Hub username.
     - `DOCKERHUB_TOKEN`: A Docker Hub access token with read/write permissions.
 
+**Release history SSOT:** [`docs/release-notes.md`](../release-notes.md). There is no root `CHANGELOG.md`. Docker Hub repository descriptions are updated from `backend/README.dockerhub.md`, `react-frontend/README.dockerhub.md`, and `backend/README.worker.dockerhub.md` via `.github/workflows/docker-publish.yml` — not from release notes.
+
 ## Versioning Strategy
 
 We use [Semantic Versioning](https://semver.org/) for our releases. Tags should follow these patterns:
@@ -23,17 +25,17 @@ The GitHub Actions workflow is configured to trigger on any tag starting with `v
 
 1.  **Update Release Notes:**
 
-    - Before creating a release, ensure the `docs/release-notes.md` file is updated with the new version information.
+    - Before creating a release, ensure the `docs/release-notes.md` file (release history SSOT) is updated with the new version information.
     - Add a new entry at the top of the version history section with:
       - Version number (e.g., `v1.0.0` or `v0.1.0-beta.1`)
       - Release date in YYYY-MM-DD format
       - Summary of changes categorized as "New Features", "Bug Fixes", and "Breaking Changes"
       - Optionally, include "Technical Details" with implementation notes
-    - You can generate a draft of changes from Git history with:
+    - You can generate an ephemeral draft of changes from Git history with:
       ```powershell
       git log <previous_tag>..HEAD --pretty=format:"- %s" > changelog.txt
       ```
-    - Review and edit the generated list, then add it to `docs/release-notes.md` under the appropriate categories.
+    - Review and edit the generated list (`changelog.txt` is gitignored), then add it to `docs/release-notes.md` under the appropriate categories.
 
 2.  **Prepare Your Branch:**
 
@@ -71,7 +73,7 @@ The GitHub Actions workflow is configured to trigger on any tag starting with `v
 
 1.  **GitHub Actions Workflow Triggered:** Pushing a tag matching the `v*` pattern automatically triggers the "Docker Publish" workflow defined in `.github/workflows/docker-publish.yml`.
 2.  **Image Build & Tag:** The workflow checks out the code corresponding to the pushed Git tag. It then builds the Docker images for the backend, frontend, and worker services. The Docker images will be tagged with the same version as the Git tag (e.g., `yourusername/fastapi-rbac-backend:v1.0.0`).
-3.  **Push to Docker Hub:** After a successful build, the tagged Docker images are pushed to your configured Docker Hub repository.
+3.  **Push to Docker Hub:** After a successful build, the tagged Docker images are pushed to your configured Docker Hub repository. The workflow also updates Hub repository descriptions from `backend/README.dockerhub.md`, `react-frontend/README.dockerhub.md`, and `backend/README.worker.dockerhub.md` (not from `docs/release-notes.md`).
 
 ## Verifying the Release
 

--- a/docs/research/graphify-automation.md
+++ b/docs/research/graphify-automation.md
@@ -195,7 +195,7 @@ Design rules:
 - **Never** fail other CI / never add as a required status check.
 - **Never** commit gitignored heavy artifacts (`graph.json`, `graph.html`).
 - Full-repo extract is intentional; no LLM / no API keys (`--code-only`, `--no-label`).
-- Bot commit/PR title must follow repo Angular+emoji style from [`.github/prompts/commit.prompt.md`](../../.github/prompts/commit.prompt.md) (e.g. `📝 docs(graphify-out): …`).
+- Bot commit/PR title must follow [`docs/agents/commit-messages.md`](../agents/commit-messages.md) (e.g. `docs(graphify): refresh GRAPH_REPORT.md`).
 - Human reviews and merges the maintenance PR like any other chore.
 
 ### Secondary: optional local hooks (option C)


### PR DESCRIPTION
## Summary
- Add canonical commit-message SSOT at `docs/agents/commit-messages.md` (plain conventional commits, no emoji, component/domain scopes) and retarget harnesses (`commit.prompt`, pre-commit instructions, AGENTS/CLAUDE/copilot, contributing, RELEASE, `.changelogrc.md`).
- Scrub stale root `CHANGELOG.md` checklist/refs; document `docs/release-notes.md` as release-history SSOT and Docker Hub descriptions from `*.dockerhub.md` via `docker-publish.yml`.

Fixes #83
Fixes #86

## Notes
- Commitlint / commit-msg hook enforcement is deferred (called out in SSOT and `.changelogrc.md`).

## Test plan
- [x] Confirm no remaining docs require updating a root `CHANGELOG.md`
- [x] Confirm agent entrypoints link to `docs/agents/commit-messages.md` and forbid emoji
- [x] Spot-check RELEASE.md Hub step names the three `*.dockerhub.md` sources
- [x] Docs-only PR; no runtime/code changes expected