### PR TITLE
fix(release): align PowerShell release script with bash

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -178,8 +178,10 @@ cd scripts/deployment/release
 - `-p, --previous-tag`: Previous tag for changelog generation (optional)
 - `-s, --skip-notes`: Skip updating release notes
 - `-b, --build-docker`: Build and push Docker images immediately
-- `-r, --dry-run`: Simulate without making changes
+- `-r, --dry-run`: Simulate without making changes (skips `git pull`; leaves temporary `changelog.txt`; does not write `VERSION` / release notes, commit, tag, or push)
 - `-h, --help`: Show help message
+
+PowerShell equivalent: `.\Create-Release.ps1 -Version v1.2.3` (same behavior: updates root `VERSION` without the `v` prefix, commits `docs/release-notes.md` + `VERSION` with `docs: update release notes and version for …`, refuses remote retags without force-push).
 
 ### Manual Release Process
 

--- a/docs/deployment/RELEASE_PROCESS.md
+++ b/docs/deployment/RELEASE_PROCESS.md
@@ -110,8 +110,9 @@ We have automation scripts that simplify the release process by handling all the
 These scripts will:
 
 - Generate a changelog from Git history
-- Update the release notes file
-- Create and push the Git tag
+- Update root `VERSION` (without the leading `v`) and `docs/release-notes.md`
+- Commit those files with `docs: update release notes and version for <tag>`
+- Create and push the Git tag (refuses if the tag already exists on remote; no force-push)
 - Optionally build and push Docker images
 
 You can use the `-DryRun` (PowerShell) or `--dry-run` (Bash) flag to simulate the release process without making any actual changes:
@@ -123,6 +124,13 @@ You can use the `-DryRun` (PowerShell) or `--dry-run` (Bash) flag to simulate th
 ```bash
 ./create-release.sh -v v0.2.0 --dry-run
 ```
+
+Dry-run behavior (both scripts):
+
+- Skips `git pull origin main` (non-mutating simulation)
+- Does not write `VERSION` or `docs/release-notes.md`, commit, tag, or push
+- Still generates temporary `changelog.txt` and leaves it in place (same as a successful dry-run cleanup message: “Would clean up”)
+- Still prompts for interactive confirmations when warnings apply
 
 For more options, run the scripts with the `-Help` or `--help` flag.
 

--- a/scripts/deployment/release/Create-Release.ps1
+++ b/scripts/deployment/release/Create-Release.ps1
@@ -2,10 +2,11 @@
 #
 # This script automates the release process for the FastAPI RBAC project by:
 # 1. Generating a changelog from Git history
-# 2. Updating the release notes file
+# 2. Updating VERSION (strip leading v) and docs/release-notes.md
 # 3. Creating and pushing a Git tag
 # 4. Optionally building and pushing Docker images
 #
+# Kept in parity with create-release.sh (Phase B / issue #84).
 # Author: FastAPI RBAC Team
 # Created: July 2, 2025
 
@@ -36,8 +37,9 @@ $ChangelogPath = Join-Path -Path $RootDir -ChildPath "changelog.txt"
 $DockerBuildScript = Join-Path -Path $RootDir -ChildPath "scripts\deployment\production\build-and-push.ps1"
 
 # Add a trap to ensure we clean up the changelog file even on error
+# Skip cleanup in dry-run so behavior matches create-release.sh
 trap {
-    if (Test-Path -Path $ChangelogPath) {
+    if (-not $DryRun -and (Test-Path -Path $ChangelogPath)) {
         Write-Host "Cleaning up changelog file after error..." -ForegroundColor Yellow
         Remove-Item -Path $ChangelogPath -Force -ErrorAction SilentlyContinue
     }
@@ -67,9 +69,14 @@ function Show-Help {
 
     Write-Host "`n📝 Process:" -ForegroundColor Yellow
     Write-Host "  1. Generate changelog from Git history" -ForegroundColor White
-    Write-Host "  2. Update release notes file (docs/release-notes.md)" -ForegroundColor White
+    Write-Host "  2. Update VERSION (strip leading v) and docs/release-notes.md" -ForegroundColor White
     Write-Host "  3. Create and push Git tag" -ForegroundColor White
     Write-Host "  4. Optionally build and push Docker images (with -BuildDocker flag)" -ForegroundColor White
+
+    Write-Host "`n🔍 Dry-run notes:" -ForegroundColor Yellow
+    Write-Host "  • Does not pull origin/main, write files, commit, tag, or push" -ForegroundColor White
+    Write-Host "  • Still writes temporary changelog.txt (left in place; matches bash dry-run)" -ForegroundColor White
+    Write-Host "  • Still requires interactive confirmations for warnings" -ForegroundColor White
 
     Write-Host "`n🔧 Requirements:" -ForegroundColor Yellow
     Write-Host "  • Git installed and configured" -ForegroundColor White
@@ -128,7 +135,12 @@ function Confirm-MainBranch {
         Write-Host "✅ Working directory is clean" -ForegroundColor Green
     }
 
-    # Pull latest changes
+    # Pull latest changes (skipped in dry-run so the simulation stays non-mutating)
+    if ($DryRun) {
+        Write-Host "🔍 [DRY RUN] Skipping git pull origin main" -ForegroundColor Cyan
+        return
+    }
+
     Write-Host "Pulling latest changes from origin/main..." -ForegroundColor Cyan
     git pull origin main
     if ($LASTEXITCODE -ne 0) {
@@ -191,7 +203,18 @@ function Update-ReleaseNotes {
         [string]$changelog
     )
 
-    Write-Host "`nUpdating release notes..." -ForegroundColor Cyan
+    Write-Host "`nUpdating release notes and VERSION file..." -ForegroundColor Cyan
+
+    # Update VERSION file (strip leading 'v' to match create-release.sh)
+    $versionWithoutV = $version -replace '^v', ''
+    $versionFilePath = Join-Path -Path $RootDir -ChildPath "VERSION"
+    if ($DryRun) {
+        Write-Host "🔍 [DRY RUN] Would update VERSION file to: $versionWithoutV" -ForegroundColor Cyan
+    }
+    else {
+        Set-Content -Path $versionFilePath -Value $versionWithoutV
+        Write-Host "✅ Updated VERSION file to: $versionWithoutV" -ForegroundColor Green
+    }
 
     # Check if release notes file exists
     if (-not (Test-Path -Path $ReleaseNotesPath)) {
@@ -256,7 +279,7 @@ $changelog
     if ($DryRun) {
         Write-Host "🔍 [DRY RUN] Would create backup of release notes at: $ReleaseNotesPath.bak" -ForegroundColor Cyan
         Write-Host "🔍 [DRY RUN] Would update release notes with new version $version" -ForegroundColor Cyan
-        Write-Host "🔍 [DRY RUN] Would commit the updated release notes" -ForegroundColor Cyan
+        Write-Host "🔍 [DRY RUN] Would commit the updated release notes and VERSION file" -ForegroundColor Cyan
         Write-Host "`nPreview of release notes changes:" -ForegroundColor Yellow
         Write-Host "=================================" -ForegroundColor Yellow
         Write-Host $newEntry -ForegroundColor White
@@ -288,19 +311,19 @@ $changelog
             Write-Host "✅ Removed backup file after confirmation" -ForegroundColor Green
         }
 
-        # Commit the updated release notes
-        Write-Host "`nCommitting the updated release notes..." -ForegroundColor Cyan
-        git add $ReleaseNotesPath
-        git commit -m "Update release notes for $version"
+        # Commit the updated release notes and VERSION file (match create-release.sh)
+        Write-Host "`nCommitting the updated release notes and VERSION file..." -ForegroundColor Cyan
+        git add $ReleaseNotesPath $versionFilePath
+        git commit -m "docs: update release notes and version for $version"
         if ($LASTEXITCODE -ne 0) {
-            Write-Host "⚠️ WARNING: Failed to commit the updated release notes." -ForegroundColor Yellow
+            Write-Host "⚠️ WARNING: Failed to commit the updated files." -ForegroundColor Yellow
             $confirmation = Read-Host "Do you want to continue anyway? (y/n)"
             if ($confirmation -ne "y") {
                 Write-Host "Operation cancelled." -ForegroundColor Red
                 exit 1
             }
         } else {
-            Write-Host "✅ Release notes committed successfully" -ForegroundColor Green
+            Write-Host "✅ Release notes and VERSION file committed successfully" -ForegroundColor Green
         }
     }
 }
@@ -318,35 +341,39 @@ function New-GitTag {
         return
     }
 
-    # Check if tag already exists
+    # Check if tag already exists locally
     $existingTags = git tag -l $version
     if ($existingTags -contains $version) {
-        Write-Host "⚠️ WARNING: Tag $version already exists." -ForegroundColor Yellow
-        $confirmation = Read-Host "Do you want to force update the existing tag? (y/n)"
+        Write-Host "⚠️ WARNING: Tag $version already exists locally." -ForegroundColor Yellow
+
+        # Refuse if the tag already exists on remote — we do not force-push tags
+        $remoteTag = git ls-remote --tags origin "refs/tags/$version" 2>$null
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($remoteTag)) {
+            Write-Host "❌ Tag $version already exists on remote. Refusing to retag." -ForegroundColor Red
+            Write-Host "This script does not force-push tags. Delete the remote tag explicitly if you intend to replace it, then re-run." -ForegroundColor Yellow
+            exit 1
+        }
+
+        $confirmation = Read-Host "Do you want to replace the local tag and push it? (y/n)"
         if ($confirmation -ne "y") {
             Write-Host "Operation cancelled." -ForegroundColor Red
             exit 1
         }
 
-        # Delete existing tag
+        # Delete existing local tag only
         git tag -d $version
         if ($LASTEXITCODE -ne 0) {
-            Write-Host "❌ Failed to delete existing tag." -ForegroundColor Red
+            Write-Host "❌ Failed to delete existing local tag." -ForegroundColor Red
             exit 1
         }
-
-        # If tag was already pushed, we need to force push
-        $tagExistsRemote = $false
-        try {
-            git ls-remote --tags origin $version | Out-Null
-            $tagExistsRemote = $LASTEXITCODE -eq 0
-        }
-        catch {
-            # Ignore errors
-        }
-
-        if ($tagExistsRemote) {
-            Write-Host "⚠️ WARNING: Tag $version exists on remote. It will be force updated." -ForegroundColor Yellow
+    }
+    else {
+        # Also refuse when remote has the tag even if local does not
+        $remoteTag = git ls-remote --tags origin "refs/tags/$version" 2>$null
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($remoteTag)) {
+            Write-Host "❌ Tag $version already exists on remote. Refusing to retag." -ForegroundColor Red
+            Write-Host "This script does not force-push tags. Delete the remote tag explicitly if you intend to replace it, then re-run." -ForegroundColor Yellow
+            exit 1
         }
     }
 
@@ -358,7 +385,7 @@ function New-GitTag {
     }
     Write-Host "✅ Git tag created successfully" -ForegroundColor Green
 
-    # Push the tag
+    # Push the tag (non-force)
     Write-Host "`nPushing Git tag to remote..." -ForegroundColor Cyan
     git push origin $version
     if ($LASTEXITCODE -ne 0) {
@@ -473,10 +500,10 @@ if ([string]::IsNullOrEmpty($PreviousTag)) {
 
 # Start the release process
 if ($DryRun) {
-    Write-Host "`n� [DRY RUN] Starting release process simulation for version: $Version" -ForegroundColor Cyan
+    Write-Host "`n🔍 [DRY RUN] Starting release process simulation for version: $Version" -ForegroundColor Cyan
     Write-Host "🔍 No actual changes will be made to files or repositories." -ForegroundColor Cyan
 } else {
-    Write-Host "`n�🚀 Starting release process for version: $Version" -ForegroundColor Green
+    Write-Host "`n🚀 Starting release process for version: $Version" -ForegroundColor Green
 }
 
 # Confirm and prepare main branch
@@ -520,12 +547,8 @@ if ($DryRun) {
 } else {
     Write-Host "`n✅ Release process completed successfully for version: $Version" -ForegroundColor Green
     Write-Host "`n📋 Next steps:" -ForegroundColor Yellow
-    Write-Host "  1. Monitor GitHub Actions workflow at: https://github.com/yourusername/fastapi_rbac/actions" -ForegroundColor White
+    Write-Host "  1. Monitor GitHub Actions workflow at: https://github.com/mnaimfaizy/fastapi_rbac/actions" -ForegroundColor White
     Write-Host "  2. Verify Docker images on Docker Hub" -ForegroundColor White
     Write-Host "  3. Notify team members about the new release" -ForegroundColor White
 }
-Write-Host "`n📋 Next steps:" -ForegroundColor Yellow
-Write-Host "  1. Monitor GitHub Actions workflow at: https://github.com/yourusername/fastapi_rbac/actions" -ForegroundColor White
-Write-Host "  2. Verify Docker images on Docker Hub" -ForegroundColor White
-Write-Host "  3. Notify team members about the new release" -ForegroundColor White
 Write-Host "`nThank you for using the FastAPI RBAC Release Automation Script! 🎉" -ForegroundColor Cyan

--- a/scripts/deployment/release/create-release.sh
+++ b/scripts/deployment/release/create-release.sh
@@ -3,9 +3,11 @@
 #
 # This script automates the release process for the FastAPI RBAC project by:
 # 1. Generating a changelog from Git history
-# 2. Updating the release notes file
+# 2. Updating VERSION (strip leading v) and docs/release-notes.md
 # 3. Creating and pushing a Git tag
 # 4. Optionally building and pushing Docker images
+#
+# Kept in parity with Create-Release.ps1 (Phase B / issue #84).
 #
 # Author: FastAPI RBAC Team
 # Created: July 2, 2025
@@ -62,9 +64,14 @@ function show_help {
 
     echo -e "\n${YELLOW}📝 Process:${NC}"
     echo -e "${WHITE}  1. Generate changelog from Git history${NC}"
-    echo -e "${WHITE}  2. Update release notes file (docs/release-notes.md)${NC}"
+    echo -e "${WHITE}  2. Update VERSION (strip leading v) and docs/release-notes.md${NC}"
     echo -e "${WHITE}  3. Create and push Git tag${NC}"
     echo -e "${WHITE}  4. Optionally build and push Docker images (with -b/--build-docker flag)${NC}"
+
+    echo -e "\n${YELLOW}🔍 Dry-run notes:${NC}"
+    echo -e "${WHITE}  • Does not pull origin/main, write release notes/VERSION, commit, tag, or push${NC}"
+    echo -e "${WHITE}  • Still writes temporary changelog.txt (left in place after dry-run)${NC}"
+    echo -e "${WHITE}  • Still requires interactive confirmations for warnings${NC}"
 
     echo -e "\n${YELLOW}🔧 Requirements:${NC}"
     echo -e "${WHITE}  • Git installed and configured${NC}"
@@ -113,7 +120,12 @@ function confirm_main_branch {
         echo -e "${GREEN}✅ Working directory is clean${NC}"
     fi
 
-    # Pull latest changes
+    # Pull latest changes (skipped in dry-run so the simulation stays non-mutating)
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${CYAN}🔍 [DRY RUN] Skipping git pull origin main${NC}"
+        return
+    fi
+
     echo -e "${CYAN}Pulling latest changes from origin/main...${NC}"
     if ! git pull origin main; then
         echo -e "${RED}❌ Failed to pull latest changes. Please resolve any conflicts and try again.${NC}"
@@ -301,24 +313,26 @@ function create_git_tag {
         return
     fi
 
-    # Check if tag already exists
+    # Refuse if the tag already exists on remote — we do not force-push tags
+    if git ls-remote --tags origin "refs/tags/$version" | grep -q "$version"; then
+        echo -e "${RED}❌ Tag $version already exists on remote. Refusing to retag.${NC}"
+        echo -e "${YELLOW}This script does not force-push tags. Delete the remote tag explicitly if you intend to replace it, then re-run.${NC}"
+        exit 1
+    fi
+
+    # Check if tag already exists locally
     if git tag -l "$version" | grep -q "$version"; then
-        echo -e "${YELLOW}⚠️ WARNING: Tag $version already exists.${NC}"
-        read -p "Do you want to force update the existing tag? (y/n): " confirmation
+        echo -e "${YELLOW}⚠️ WARNING: Tag $version already exists locally.${NC}"
+        read -p "Do you want to replace the local tag and push it? (y/n): " confirmation
         if [ "$confirmation" != "y" ]; then
             echo -e "${RED}Operation cancelled.${NC}"
             exit 1
         fi
 
-        # Delete existing tag
+        # Delete existing local tag only
         if ! git tag -d "$version"; then
-            echo -e "${RED}❌ Failed to delete existing tag.${NC}"
+            echo -e "${RED}❌ Failed to delete existing local tag.${NC}"
             exit 1
-        fi
-
-        # If tag was already pushed, we need to force push
-        if git ls-remote --tags origin "$version" &>/dev/null; then
-            echo -e "${YELLOW}⚠️ WARNING: Tag $version exists on remote. It will be force updated.${NC}"
         fi
     fi
 
@@ -329,7 +343,7 @@ function create_git_tag {
     fi
     echo -e "${GREEN}✅ Git tag created successfully${NC}"
 
-    # Push the tag
+    # Push the tag (non-force)
     echo -e "\n${CYAN}Pushing Git tag to remote...${NC}"
     if ! git push origin "$version"; then
         echo -e "${RED}❌ Failed to push Git tag to remote.${NC}"
@@ -505,7 +519,7 @@ if [ "$DRY_RUN" = true ]; then
 else
     echo -e "\n${GREEN}✅ Release process completed successfully for version: $VERSION${NC}"
     echo -e "\n${YELLOW}📋 Next steps:${NC}"
-    echo -e "${WHITE}  1. Monitor GitHub Actions workflow at: https://github.com/yourusername/fastapi_rbac/actions${NC}"
+    echo -e "${WHITE}  1. Monitor GitHub Actions workflow at: https://github.com/mnaimfaizy/fastapi_rbac/actions${NC}"
     echo -e "${WHITE}  2. Verify Docker images on Docker Hub${NC}"
     echo -e "${WHITE}  3. Notify team members about the new release${NC}"
 fi


### PR DESCRIPTION
## Summary
- Align `Create-Release.ps1` with `create-release.sh`: update root `VERSION` (strip `v`), commit `docs/release-notes.md` + `VERSION` with conventional message
- Fix Actions URL to `mnaimfaizy/fastapi_rbac`; refuse unsafe remote retag (no claimed force-push)
- Skip `git pull` in dry-run; document dry-run cleanup/`changelog.txt` behavior

## Test plan
- [x] Run `.\Create-Release.ps1 -Help` and `./create-release.sh --help` and confirm dry-run notes + VERSION step
- [x] Dry-run on clean tree: `.\Create-Release.ps1 -Version v0.0.0-test -DryRun` (confirm no pull, VERSION/notes not written, changelog.txt left)
- [x] Confirm remote retag path refuses when tag exists on origin (message about no force-push)
- [x] Spot-check commit message and Actions URL strings in both scripts

Closes #84

Made with [Cursor](https://cursor.com)