### PR TITLE
feat(release): Release PR flow, tag-on-merge, and release skill

### DIFF
--- a/.claude/agents/release-notes.md
+++ b/.claude/agents/release-notes.md
@@ -1,0 +1,26 @@
+# Release Notes Agent (Claude)
+
+Harness wrapper for Claude Code / Claude agents. **Behavior SSOT:** [`docs/agents/release-notes-agent.md`](../../docs/agents/release-notes-agent.md)
+
+## Model
+
+Set your preferred model for this sub-agent here (edit as needed):
+
+```text
+MODEL: <assign-claude-model>
+```
+
+Examples (replace the placeholder): `claude-sonnet-4`, `claude-opus-4`, etc. — use whatever your Claude harness currently supports.
+
+## How to invoke
+
+When the release orchestrator (or a human) needs release notes:
+
+1. Gather version, previous tag, commit list (`git log <prev>..HEAD`), and today’s date.
+2. Launch this agent / Task with those inputs.
+3. Instruct it: **Read and follow `docs/agents/release-notes-agent.md` exactly.** Return only the markdown section.
+4. Do not restate categorization rules in the Task prompt beyond pointing at that file.
+
+## Outputs
+
+Pass the returned markdown section to the release skill / `Create-Release` scripts via `-NotesFile` / `--notes-file`.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: release
+description: >-
+  Prepare a Release PR for FastAPI RBAC: propose SemVer, gather commits since
+  the last tag, draft release notes via the release-notes sub-agent, run
+  create-release scripts in Release PR mode, and return the PR URL. Use when
+  the user asks to cut a release, open a release PR, or ship a version.
+disable-model-invocation: true
+---
+
+# Release
+
+Orchestrate a **Release PR** (not a direct tag). After merge, CI tags and publishes Docker images.
+
+## Canonical docs
+
+- Commit format: [`docs/agents/commit-messages.md`](../../../docs/agents/commit-messages.md)
+- Notes agent behavior: [`docs/agents/release-notes-agent.md`](../../../docs/agents/release-notes-agent.md)
+- Harness wrapper (Cursor): [`.cursor/agents/release-notes.md`](../../../.cursor/agents/release-notes.md)
+- Scripts: `scripts/deployment/release/Create-Release.ps1` / `create-release.sh`
+
+## Preconditions
+
+- Clean working tree; start from up-to-date `main` (scripts enforce this with `-Yes` / `--yes`).
+- `gh` CLI authenticated.
+- Do **not** use `-DirectTag` / `--direct-tag` unless the user explicitly demands the emergency path.
+
+## Workflow
+
+Copy and track:
+
+```text
+Release progress:
+- [ ] 1. Sync main / confirm clean tree
+- [ ] 2. Propose version; wait for user confirm or override
+- [ ] 3. Gather commits since previous tag
+- [ ] 4. Draft notes via release-notes sub-agent
+- [ ] 5. Write notes to a temp file
+- [ ] 6. Run create-release (Release PR mode, non-interactive)
+- [ ] 7. Return only the PR URL (+ one-line next steps)
+```
+
+### 1. Sync
+
+```powershell
+git checkout main
+git pull origin main
+git status
+```
+
+### 2. Propose version
+
+- Read `VERSION` and latest tag: `git tag -l --sort=-v:refname` / `git describe --tags --abbrev=0`
+- Inspect commits since last tag for SemVer hints (`feat` → minor, `fix` → patch, breaking → major; prerelease suffixes if current line is beta/rc)
+- **Propose** `vX.Y.Z` (or prerelease) and **wait** for the user to confirm or override
+- Never invent a version and proceed without confirmation
+
+### 3. Gather commits
+
+```powershell
+git log <previous_tag>..HEAD --pretty=format:"%s%n%b%n---"
+```
+
+If no previous tag, use full history (same as scripts).
+
+### 4. Draft notes (sub-agent — mandatory)
+
+Do **not** draft the release-notes section yourself.
+
+1. Read [`.cursor/agents/release-notes.md`](../../../.cursor/agents/release-notes.md) (or `.claude/agents/release-notes.md` in Claude).
+2. Launch a **Task / sub-agent** with:
+   - Version (confirmed)
+   - Previous tag
+   - Commit list from step 3
+   - Today’s date (`YYYY-MM-DD`)
+   - Instruction: follow [`docs/agents/release-notes-agent.md`](../../../docs/agents/release-notes-agent.md) exactly; return **only** the markdown section
+3. Prefer the model noted in the harness wrapper’s `MODEL:` field when the UI allows choosing a model.
+
+### 5. Temp notes file
+
+Write the sub-agent output to a temp path, e.g. `$env:TEMP/release-notes-<version>.md` (must be the full `### v…` section).
+
+### 6. Create Release PR
+
+**PowerShell (Windows):**
+
+```powershell
+cd scripts/deployment/release
+.\Create-Release.ps1 -Version vX.Y.Z -NotesFile $notesPath -Yes
+```
+
+**Bash:**
+
+```bash
+./scripts/deployment/release/create-release.sh -v vX.Y.Z --notes-file "$notesPath" --yes
+```
+
+Optional dry-run first: add `-DryRun` / `--dry-run` (still writes `changelog.txt`; does not mutate VERSION/notes/remotes).
+
+### 7. Finish
+
+- Print the **PR URL** from the script output (primary deliverable).
+- One-line reminder: after merge, `release-tag-on-merge` creates the tag + GitHub Release; `docker-publish` builds images once from the `v*` tag.
+- Do not merge the PR unless the user asks.
+- Do not push tags yourself.
+
+## Out of scope
+
+- Production deploy
+- Editing `*.dockerhub.md`
+- `-DirectTag` unless explicitly requested
+- Rewriting historical commits

--- a/.cursor/agents/release-notes.md
+++ b/.cursor/agents/release-notes.md
@@ -1,0 +1,26 @@
+# Release Notes Agent (Cursor)
+
+Harness wrapper for Cursor agents. **Behavior SSOT:** [`docs/agents/release-notes-agent.md`](../../docs/agents/release-notes-agent.md)
+
+## Model
+
+Set your preferred model for this sub-agent here (edit as needed):
+
+```text
+MODEL: <assign-cursor-model>
+```
+
+Pick a model in Cursor’s agent / Task UI for this sub-agent when invoking it.
+
+## How to invoke
+
+When the release orchestrator (`.claude/skills/release`) or a human needs release notes:
+
+1. Gather version, previous tag, commit list (`git log <prev>..HEAD`), and today’s date.
+2. Use the Task tool (`generalPurpose` or equivalent) with those inputs.
+3. Instruct it: **Read and follow `docs/agents/release-notes-agent.md` exactly.** Return only the markdown section.
+4. Do not duplicate commit→section rules in the prompt; link the canonical file.
+
+## Outputs
+
+Pass the returned markdown section to the release skill / scripts via `-NotesFile` / `--notes-file`.

--- a/.github/agents/release-notes.md
+++ b/.github/agents/release-notes.md
@@ -1,0 +1,25 @@
+# Release Notes Agent (GitHub / Copilot)
+
+Harness wrapper for GitHub Copilot coding agent / custom agents. **Behavior SSOT:** [`docs/agents/release-notes-agent.md`](../../docs/agents/release-notes-agent.md)
+
+## Model
+
+Set your preferred model for this sub-agent here (edit as needed):
+
+```text
+MODEL: <assign-github-copilot-model>
+```
+
+Configure the model in the Copilot / GitHub agent settings that load this file.
+
+## How to invoke
+
+When preparing a release:
+
+1. Gather version, previous tag, commit list (`git log <prev>..HEAD`), and today’s date.
+2. Run this agent with those inputs.
+3. Instruct it: **Read and follow `docs/agents/release-notes-agent.md` exactly.** Return only the markdown section.
+
+## Outputs
+
+Save the section to a temp file and pass it to `scripts/deployment/release/create-release.sh --notes-file …` (or the PowerShell equivalent).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,8 @@ This project is a user-management microservice: FastAPI backend + React/TypeScri
 | Frontend troubleshooting | [`docs/troubleshooting/frontend-issues.md`](../docs/troubleshooting/frontend-issues.md) |
 | Knowledge graph | [`docs/agents/graphify.md`](../docs/agents/graphify.md) |
 | Commit messages (mandatory SSOT) | [`docs/agents/commit-messages.md`](../docs/agents/commit-messages.md) |
+| Release notes agent (canonical) | [`docs/agents/release-notes-agent.md`](../docs/agents/release-notes-agent.md) |
+| Release skill (Release PR) | [`.claude/skills/release/SKILL.md`](../.claude/skills/release/SKILL.md) |
 
 If `graphify-out/graph.json` exists, prefer `graphify query` / `path` / `explain` for “how does X connect to Y” questions.
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,10 @@
 name: Docker Publish
 
+# Publish on v* tag push (or manual dispatch). Do not also trigger on
+# release: published — Release Tag on Merge creates a GitHub Release after the
+# tag, which would double-build images if both triggers were enabled.
+
 on:
-  release:
-    types: [published]
   push:
     tags:
       - "v*" # Trigger on version tags like v1.0, v1.1.2, etc.
@@ -65,11 +67,8 @@ jobs:
           elif [[ "${{ github.ref_type }}" == "tag" ]]; then
             IMAGE_TAG="${{ github.ref_name }}"
             echo "Using Git tag as IMAGE_TAG: ${IMAGE_TAG}"
-          elif [[ "${{ github.event_name }}" == "release" ]]; then
-            IMAGE_TAG="${{ github.event.release.tag_name }}"
-            echo "Using release tag_name as IMAGE_TAG: ${IMAGE_TAG}"
           else
-            echo "::error::Unsupported event '${{ github.event_name }}'. Trigger via release, v* tag, or workflow_dispatch."
+            echo "::error::Unsupported event '${{ github.event_name }}'. Trigger via v* tag push or workflow_dispatch."
             exit 1
           fi
 
@@ -259,7 +258,7 @@ jobs:
             echo "1. Check which step failed above (validation, login, backend/frontend/worker build, or Hub description)."
             echo "2. Worker must build from \`backend/queue.dockerfile.prod\` (not \`Dockerfile.prod --target worker\`)."
             echo "3. Verify \`DOCKERHUB_USERNAME\` / \`DOCKERHUB_TOKEN\` secrets."
-            echo "4. Confirm \`IMAGE_TAG\` was set (release tag, \`v*\` push, or workflow_dispatch input)."
+            echo "4. Confirm \`IMAGE_TAG\` was set (\`v*\` tag push or workflow_dispatch input)."
             echo "5. Re-run via Actions → Docker Publish → Run workflow after fixing."
           } >> "$GITHUB_STEP_SUMMARY"
         shell: bash

--- a/.github/workflows/release-tag-on-merge.yml
+++ b/.github/workflows/release-tag-on-merge.yml
@@ -1,0 +1,152 @@
+name: Release Tag on Merge
+
+# When a Release PR (head branch release/v*) is merged into main, create the
+# annotated SemVer tag and a GitHub Release. Branch name is the version SSOT.
+# Docker images publish via docker-publish.yml on the v* tag push (not on
+# release: published — that trigger was removed to avoid double builds).
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag-and-release:
+    name: Tag and GitHub Release
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse version from release branch
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/}"
+
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid release branch '${BRANCH}'. Expected release/vX.Y.Z or release/vX.Y.Z-suffix."
+            exit 1
+          fi
+
+          VERSION_FILE_EXPECTED="${VERSION#v}"
+          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
+            PRERELEASE=true
+          else
+            PRERELEASE=false
+          fi
+
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "version_file=${VERSION_FILE_EXPECTED}" >> "$GITHUB_OUTPUT"
+          echo "prerelease=${PRERELEASE}" >> "$GITHUB_OUTPUT"
+          echo "Parsed version=${VERSION} prerelease=${PRERELEASE}"
+
+      - name: Checkout merge commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Verify VERSION file matches branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          EXPECTED="${{ steps.version.outputs.version_file }}"
+          if [[ ! -f VERSION ]]; then
+            echo "::error::VERSION file missing on merge commit."
+            exit 1
+          fi
+          ACTUAL="$(tr -d '[:space:]' < VERSION)"
+          if [[ "$ACTUAL" != "$EXPECTED" ]]; then
+            echo "::error::VERSION file ('${ACTUAL}') does not match branch SSOT ('${EXPECTED}' from ${{ steps.version.outputs.branch }})."
+            exit 1
+          fi
+          echo "VERSION file matches branch SSOT: ${ACTUAL}"
+
+      - name: Refuse if tag already exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          if git ls-remote --tags origin "refs/tags/${VERSION}" | grep -q "${VERSION}"; then
+            echo "::error::Tag ${VERSION} already exists on remote. Refusing to retag (no force-push)."
+            exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag ${VERSION} already exists locally after checkout. Refusing to retag."
+            exit 1
+          fi
+          echo "Tag ${VERSION} does not exist yet — OK to create."
+
+      - name: Extract release notes section
+        id: notes
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          NOTES_FILE="${RUNNER_TEMP}/release-notes-body.md"
+
+          if [[ ! -f docs/release-notes.md ]]; then
+            echo "::error::docs/release-notes.md missing."
+            exit 1
+          fi
+
+          # Capture from "### vX.Y.Z (" until the next "### " heading (exclusive).
+          awk -v ver="$VERSION" '
+            $0 ~ "^### " ver " \\(" {flag=1; print; next}
+            /^### / {flag=0}
+            flag {print}
+          ' docs/release-notes.md > "$NOTES_FILE"
+
+          if [[ ! -s "$NOTES_FILE" ]]; then
+            echo "::warning::No matching section for ${VERSION} in docs/release-notes.md; using a minimal body."
+            printf 'Release %s\n' "$VERSION" > "$NOTES_FILE"
+          fi
+
+          echo "path=${NOTES_FILE}" >> "$GITHUB_OUTPUT"
+          echo "Extracted notes ($(wc -l < "$NOTES_FILE") lines):"
+          head -n 40 "$NOTES_FILE"
+
+      - name: Create annotated tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${VERSION}" -m "Release ${VERSION}"
+          git push origin "refs/tags/${VERSION}"
+          echo "Pushed annotated tag ${VERSION}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          NOTES_FILE="${{ steps.notes.outputs.path }}"
+          PRERELEASE="${{ steps.version.outputs.prerelease }}"
+
+          EXTRA_ARGS=()
+          if [[ "$PRERELEASE" == "true" ]]; then
+            EXTRA_ARGS+=(--prerelease)
+          fi
+
+          gh release create "${VERSION}" \
+            --title "${VERSION}" \
+            --notes-file "${NOTES_FILE}" \
+            "${EXTRA_ARGS[@]}"
+
+          echo "Created GitHub Release ${VERSION} (prerelease=${PRERELEASE})"
+          echo "### Release created" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Tag / release: \`${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Branch SSOT: \`${{ steps.version.outputs.branch }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Pre-release: \`${PRERELEASE}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Docker Publish should run once from the tag push." >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository includes Matt Pocock engineering skills in `.claude/skills`.
 
 Use these skills as available workflows:
 
-- User-invoked: `ask-matt`, `grill-with-docs`, `triage`, `improve-codebase-architecture`, `setup-matt-pocock-skills`, `to-issues`, `to-prd`, `implement`
+- User-invoked: `ask-matt`, `grill-with-docs`, `triage`, `improve-codebase-architecture`, `setup-matt-pocock-skills`, `to-issues`, `to-prd`, `implement`, `release`
 - Model-invoked: `prototype`, `diagnosing-bugs`, `research`, `tdd`, `domain-modeling`, `codebase-design`, `code-review`
 
 ## Agent skills
@@ -32,6 +32,10 @@ If `graphify-out/graph.json` exists, **query it first** for architecture and mod
 ### Commit messages (mandatory)
 
 Commit messages must follow [`docs/agents/commit-messages.md`](docs/agents/commit-messages.md). This is not optional: plain conventional commits, no emoji, component/domain scopes. Release-note generation depends on consistent history.
+
+### Release
+
+User-invoked [`release`](.claude/skills/release/SKILL.md) skill: propose version → release-notes sub-agent → Release PR → return PR URL. Notes agent SSOT: [`docs/agents/release-notes-agent.md`](docs/agents/release-notes-agent.md).
 
 ## Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,10 @@ If `graphify-out/graph.json` exists, query it first for architecture questions. 
 
 Commit messages must follow [`docs/agents/commit-messages.md`](docs/agents/commit-messages.md). This is not optional: plain conventional commits, no emoji, component/domain scopes.
 
+### Release
+
+User-invoked skill: `.claude/skills/release`. Opens a Release PR (notes via release-notes sub-agent). Canonical notes behavior: [`docs/agents/release-notes-agent.md`](docs/agents/release-notes-agent.md).
+
 ## Project conventions
 
 When working in this repository, follow conventions in:

--- a/docs/agents/commit-messages.md
+++ b/docs/agents/commit-messages.md
@@ -161,5 +161,6 @@ Format is mandatory for humans and agents. A commit-msg / commitlint hook is a d
 
 - [`.changelogrc.md`](../../.changelogrc.md) — changelog section mapping, SemVer bump rules, tooling notes
 - [`docs/release-notes.md`](../release-notes.md) — committed release history (SSOT)
+- [`docs/agents/release-notes-agent.md`](release-notes-agent.md) — how to draft a release-notes section from commits
 - [Conventional Commits](https://www.conventionalcommits.org/)
 - [Semantic Versioning](https://semver.org/)

--- a/docs/agents/release-notes-agent.md
+++ b/docs/agents/release-notes-agent.md
@@ -1,0 +1,73 @@
+# Release Notes Agent (canonical)
+
+**This file is the single source of truth for drafting a release-notes section.**
+
+Harness wrappers under `.claude/agents/`, `.cursor/agents/`, and `.github/agents/` only configure how to invoke this agent and which model to use. They must not redefine categorization rules.
+
+## Role
+
+You draft **one** new version section for [`docs/release-notes.md`](../release-notes.md) from commits since the previous release tag. You do **not** open PRs, bump `VERSION`, create tags, or edit other files unless the caller explicitly asks you only to produce the markdown section.
+
+## Required inputs (from the orchestrator)
+
+The caller must provide:
+
+1. **Version** — SemVer tag including the `v` prefix (e.g. `v0.0.4-beta`)
+2. **Previous tag** — last release tag (or “none” for first release)
+3. **Commit list** — subjects (and bodies when available) from `previous_tag..HEAD`, preferably full conventional-commit messages
+4. **Today’s date** — `YYYY-MM-DD` (caller supplies; do not invent)
+
+Optional: product context or “highlight these issues.”
+
+## Rules you must follow
+
+1. Read and obey [`docs/agents/commit-messages.md`](commit-messages.md) for type → section mapping and breaking-change markers.
+2. Use [`.changelogrc.md`](../../.changelogrc.md) only as additional SemVer / section background; **commit-messages.md wins** on conflicts.
+3. Categorize every user-facing commit. Prefer these sections (omit empty ones except Breaking Changes):
+
+   - **New Features** — `feat`
+   - **Bug Fixes** — `fix`
+   - **Breaking Changes** — `!` or `BREAKING CHANGE:` (always include this heading; use `- None` if empty)
+   - **Performance** — `perf` (optional heading)
+   - **Security** — `security` (optional)
+   - **Documentation** — meaningful `docs` (optional)
+   - **Technical Details** — `refactor`, `test`, `build`, `ci`, notable `chore`, and other operator-relevant internals
+
+4. Rewrite commit subjects into clear, user-facing bullets (imperative or past tense is fine in notes; be consistent within the section). Do **not** paste raw `feat(scope):` prefixes into bullets.
+5. Drop noise: pure `style`, trivial typos, “fix typo”, merge commits, and internal-only chores that do not affect operators or users.
+6. Never invent features that are not supported by the commit list.
+7. Do not mention Docker Hub READMEs unless commits changed them; Hub descriptions are separate (`*.dockerhub.md`).
+
+## Output format
+
+Return **only** the markdown section to insert under `## Version History` (no surrounding commentary, no code fences unless a bullet truly needs one):
+
+```markdown
+### vX.Y.Z (YYYY-MM-DD)
+
+**New Features:**
+
+- …
+
+**Bug Fixes:**
+
+- …
+
+**Breaking Changes:**
+
+- None
+
+**Technical Details:**
+
+- …
+```
+
+Include optional section headings only when they have bullets. Always include **Breaking Changes**.
+
+If the version has a SemVer prerelease suffix (e.g. `-beta.1`), you may add a one-line italic note under the heading such as `_Pre-release._` — optional.
+
+## Quality bar
+
+- A maintainer should be able to paste this into `docs/release-notes.md` with minimal edits.
+- Prefer fewer, clearer bullets over dumping every commit.
+- Group related commits into one bullet when they are one change.

--- a/scripts/deployment/release/Create-Release.ps1
+++ b/scripts/deployment/release/Create-Release.ps1
@@ -1,12 +1,9 @@
 # Create-Release.ps1 - FastAPI RBAC Release Automation Script
 #
-# This script automates the release process for the FastAPI RBAC project by:
-# 1. Generating a changelog from Git history
-# 2. Updating VERSION (strip leading v) and docs/release-notes.md
-# 3. Creating and pushing a Git tag
-# 4. Optionally building and pushing Docker images
+# Default: Release PR mode (branch release/vX.Y.Z, VERSION + notes, push, gh pr create).
+# Emergency: -DirectTag tags from main (discouraged).
+# Kept in parity with create-release.sh (Phase C1).
 #
-# Kept in parity with create-release.sh (Phase B / issue #84).
 # Author: FastAPI RBAC Team
 # Created: July 2, 2025
 
@@ -18,10 +15,19 @@ param(
     [string]$PreviousTag,
 
     [Parameter(Mandatory=$false)]
+    [string]$NotesFile,
+
+    [Parameter(Mandatory=$false)]
     [switch]$SkipNotes,
 
     [Parameter(Mandatory=$false)]
     [switch]$BuildDocker,
+
+    [Parameter(Mandatory=$false)]
+    [switch]$DirectTag,
+
+    [Parameter(Mandatory=$false)]
+    [switch]$Yes,
 
     [Parameter(Mandatory=$false)]
     [switch]$DryRun,
@@ -34,54 +40,50 @@ $ErrorActionPreference = "Stop"
 $RootDir = (Get-Item (Split-Path -Parent $PSCommandPath)).Parent.Parent.Parent.FullName
 $ReleaseNotesPath = Join-Path -Path $RootDir -ChildPath "docs\release-notes.md"
 $ChangelogPath = Join-Path -Path $RootDir -ChildPath "changelog.txt"
+$VersionFilePath = Join-Path -Path $RootDir -ChildPath "VERSION"
 $DockerBuildScript = Join-Path -Path $RootDir -ChildPath "scripts\deployment\production\build-and-push.ps1"
+$RepoActionsUrl = "https://github.com/mnaimfaizy/fastapi_rbac/actions"
 
-# Add a trap to ensure we clean up the changelog file even on error
-# Skip cleanup in dry-run so behavior matches create-release.sh
 trap {
     if (-not $DryRun -and (Test-Path -Path $ChangelogPath)) {
         Write-Host "Cleaning up changelog file after error..." -ForegroundColor Yellow
         Remove-Item -Path $ChangelogPath -Force -ErrorAction SilentlyContinue
     }
-    # Re-throw the error to ensure the script exits with the proper error code
     throw $_
 }
 
 function Show-Help {
-    Write-Host "`n🚀 FastAPI RBAC Release Automation Script" -ForegroundColor Cyan
-    Write-Host "==========================================" -ForegroundColor Cyan
-    Write-Host "`nThis script automates the release process for the FastAPI RBAC project.`n" -ForegroundColor White
+    Write-Host "`nFastAPI RBAC Release Automation Script" -ForegroundColor Cyan
+    Write-Host "======================================" -ForegroundColor Cyan
+    Write-Host "`nDefault mode opens a Release PR (release/vX.Y.Z). Use -DirectTag only for emergencies.`n" -ForegroundColor White
 
-    Write-Host "📋 Parameters:" -ForegroundColor Yellow
-    Write-Host "  -Version        : Version to release (e.g., v1.0.0, v0.1.0-beta.1)" -ForegroundColor White
-    Write-Host "  -PreviousTag    : Previous tag to generate changelog from (defaults to latest tag)" -ForegroundColor White
-    Write-Host "  -SkipNotes      : Skip updating release notes (just create and push tag)" -ForegroundColor White
-    Write-Host "  -BuildDocker    : Build and push Docker images (opt-in)" -ForegroundColor White
-    Write-Host "  -DryRun         : Simulate the release process without making actual changes" -ForegroundColor White
-    Write-Host "  -Help           : Show this help message" -ForegroundColor White
+    Write-Host "Parameters:" -ForegroundColor Yellow
+    Write-Host "  -Version        : Version to release (e.g., v1.0.0, v0.1.0-beta.1) [required]" -ForegroundColor White
+    Write-Host "  -PreviousTag    : Previous tag for changelog (defaults to latest tag)" -ForegroundColor White
+    Write-Host "  -NotesFile      : Path to a release-notes section to insert (full ### entry or body)" -ForegroundColor White
+    Write-Host "  -SkipNotes      : Skip updating docs/release-notes.md (still updates VERSION in PR mode)" -ForegroundColor White
+    Write-Host "  -DirectTag      : EMERGENCY — commit on main and push tag (skips Release PR)" -ForegroundColor White
+    Write-Host '  -Yes            : Non-interactive (no prompts; fail closed on unsafe warnings)' -ForegroundColor White
+    Write-Host '  -BuildDocker    : Build/push images locally (DirectTag only; opt-in)' -ForegroundColor White
+    Write-Host "  -DryRun         : Simulate without mutating git remotes or release files" -ForegroundColor White
+    Write-Host "  -Help           : Show this help" -ForegroundColor White
 
-    Write-Host "`n💡 Examples:" -ForegroundColor Yellow
-    Write-Host "  .\Create-Release.ps1 -Version v1.0.0" -ForegroundColor White
-    Write-Host "  .\Create-Release.ps1 -Version v1.0.0 -PreviousTag v0.9.0" -ForegroundColor White
-    Write-Host "  .\Create-Release.ps1 -Version v1.0.0 -SkipNotes" -ForegroundColor White
-    Write-Host "  .\Create-Release.ps1 -Version v1.0.0 -BuildDocker" -ForegroundColor White
+    Write-Host "`nExamples:" -ForegroundColor Yellow
+    Write-Host "  .\Create-Release.ps1 -Version v1.0.0 -Yes" -ForegroundColor White
+    Write-Host "  .\Create-Release.ps1 -Version v1.0.0 -NotesFile .\notes-section.md -Yes" -ForegroundColor White
     Write-Host "  .\Create-Release.ps1 -Version v1.0.0 -DryRun" -ForegroundColor White
+    Write-Host "  .\Create-Release.ps1 -Version v1.0.0 -DirectTag -Yes   # discouraged" -ForegroundColor White
 
-    Write-Host "`n📝 Process:" -ForegroundColor Yellow
-    Write-Host "  1. Generate changelog from Git history" -ForegroundColor White
-    Write-Host "  2. Update VERSION (strip leading v) and docs/release-notes.md" -ForegroundColor White
-    Write-Host "  3. Create and push Git tag" -ForegroundColor White
-    Write-Host "  4. Optionally build and push Docker images (with -BuildDocker flag)" -ForegroundColor White
+    Write-Host "`nDefault process (Release PR):" -ForegroundColor Yellow
+    Write-Host "  1. Ensure main is clean and up to date" -ForegroundColor White
+    Write-Host "  2. Create branch release/<version> (branch name is version SSOT)" -ForegroundColor White
+    Write-Host "  3. Update VERSION + docs/release-notes.md and commit" -ForegroundColor White
+    Write-Host "  4. Push branch and open PR with gh; print PR URL" -ForegroundColor White
+    Write-Host "  5. After merge, CI creates the tag / GitHub Release (Phase C2+)" -ForegroundColor White
 
-    Write-Host "`n🔍 Dry-run notes:" -ForegroundColor Yellow
-    Write-Host "  • Does not pull origin/main, write files, commit, tag, or push" -ForegroundColor White
-    Write-Host "  • Still writes temporary changelog.txt (left in place; matches bash dry-run)" -ForegroundColor White
-    Write-Host "  • Still requires interactive confirmations for warnings" -ForegroundColor White
-
-    Write-Host "`n🔧 Requirements:" -ForegroundColor Yellow
-    Write-Host "  • Git installed and configured" -ForegroundColor White
-    Write-Host "  • Access to the repository" -ForegroundColor White
-    Write-Host "  • Docker installed and running (if using -BuildDocker)" -ForegroundColor White
+    Write-Host "`nDry-run notes:" -ForegroundColor Yellow
+    Write-Host "  • Skips git pull, file writes, commit, push, tag, and gh pr create" -ForegroundColor White
+    Write-Host "  • Still writes temporary changelog.txt (left in place)" -ForegroundColor White
 
     Write-Host ""
 }
@@ -96,10 +98,24 @@ function Test-GitAvailable {
     }
 }
 
+function Test-GhAvailable {
+    try {
+        $null = gh --version
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
 function Get-LatestGitTag {
     try {
-        $tag = git describe --tags --abbrev=0
-        return $tag
+        $tag = git describe --tags --abbrev=0 2>$null
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($tag)) {
+            Write-Host "No previous tags found. This appears to be the first release." -ForegroundColor Yellow
+            return $null
+        }
+        return $tag.Trim()
     }
     catch {
         Write-Host "No previous tags found. This appears to be the first release." -ForegroundColor Yellow
@@ -107,47 +123,77 @@ function Get-LatestGitTag {
     }
 }
 
-function Confirm-MainBranch {
+function Confirm-Continue {
+    param (
+        [string]$Prompt,
+        [switch]$AllowYesContinue
+    )
+    if ($Yes) {
+        if ($AllowYesContinue) {
+            Write-Host "Continuing (-Yes): $Prompt" -ForegroundColor Yellow
+            return $true
+        }
+        Write-Host "Non-interactive (-Yes): refusing to continue without confirmation." -ForegroundColor Red
+        Write-Host "  $Prompt" -ForegroundColor Yellow
+        exit 1
+    }
+    $confirmation = Read-Host "$Prompt (y/n)"
+    return ($confirmation -eq "y")
+}
+
+function Assert-MainClean {
+    param (
+        [switch]$PullMain
+    )
+
     $currentBranch = git rev-parse --abbrev-ref HEAD
     if ($currentBranch -ne "main") {
-        Write-Host "⚠️ WARNING: You are not on the 'main' branch. Current branch: $currentBranch" -ForegroundColor Yellow
-        $confirmation = Read-Host "Do you want to continue anyway? (y/n)"
-        if ($confirmation -ne "y") {
+        Write-Host "WARNING: You are not on the 'main' branch. Current branch: $currentBranch" -ForegroundColor Yellow
+        if ($Yes) {
+            Write-Host "Non-interactive (-Yes): must start from main." -ForegroundColor Red
+            exit 1
+        }
+        if (-not (Confirm-Continue -Prompt "Do you want to continue anyway?")) {
             Write-Host "Operation cancelled. Please switch to the main branch and try again." -ForegroundColor Red
             exit 1
         }
     }
     else {
-        Write-Host "✅ Current branch is 'main'" -ForegroundColor Green
+        Write-Host "Current branch is 'main'" -ForegroundColor Green
     }
 
-    # Check for uncommitted changes
     $status = git status --porcelain
     if ($status) {
-        Write-Host "⚠️ WARNING: You have uncommitted changes in your working directory." -ForegroundColor Yellow
-        $confirmation = Read-Host "Do you want to continue anyway? (y/n)"
-        if ($confirmation -ne "y") {
+        Write-Host "WARNING: You have uncommitted changes in your working directory." -ForegroundColor Yellow
+        if ($Yes) {
+            Write-Host "Non-interactive (-Yes): working tree must be clean." -ForegroundColor Red
+            exit 1
+        }
+        if (-not (Confirm-Continue -Prompt "Do you want to continue anyway?")) {
             Write-Host "Operation cancelled. Please commit or stash your changes and try again." -ForegroundColor Red
             exit 1
         }
     }
     else {
-        Write-Host "✅ Working directory is clean" -ForegroundColor Green
+        Write-Host "Working directory is clean" -ForegroundColor Green
     }
 
-    # Pull latest changes (skipped in dry-run so the simulation stays non-mutating)
+    if (-not $PullMain) {
+        return
+    }
+
     if ($DryRun) {
-        Write-Host "🔍 [DRY RUN] Skipping git pull origin main" -ForegroundColor Cyan
+        Write-Host "[DRY RUN] Skipping git pull origin main" -ForegroundColor Cyan
         return
     }
 
     Write-Host "Pulling latest changes from origin/main..." -ForegroundColor Cyan
     git pull origin main
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "❌ Failed to pull latest changes. Please resolve any conflicts and try again." -ForegroundColor Red
+        Write-Host "Failed to pull latest changes. Please resolve any conflicts and try again." -ForegroundColor Red
         exit 1
     }
-    Write-Host "✅ Successfully pulled latest changes" -ForegroundColor Green
+    Write-Host "Successfully pulled latest changes" -ForegroundColor Green
 }
 
 function New-Changelog {
@@ -158,38 +204,33 @@ function New-Changelog {
 
     Write-Host "Generating changelog from Git history..." -ForegroundColor Cyan
 
-    # Clean up any existing changelog file
     if (Test-Path -Path $ChangelogPath) {
         Remove-Item -Path $ChangelogPath -Force
         Write-Host "Removed existing changelog file" -ForegroundColor Cyan
     }
 
     if ([string]::IsNullOrEmpty($previousTag)) {
-        # If this is the first release, get all commits
         git log --pretty=format:"- %s" > $ChangelogPath
     }
     else {
-        # Get commits between tags
         git log "$previousTag..HEAD" --pretty=format:"- %s" > $ChangelogPath
     }
 
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "❌ Failed to generate changelog." -ForegroundColor Red
+        Write-Host "Failed to generate changelog." -ForegroundColor Red
         exit 1
     }
 
-    # Read the changelog
     $changelog = Get-Content -Path $ChangelogPath -Raw
     if ([string]::IsNullOrWhiteSpace($changelog)) {
-        Write-Host "⚠️ WARNING: No commits found between $previousTag and HEAD." -ForegroundColor Yellow
-        $confirmation = Read-Host "Do you want to continue anyway? (y/n)"
-        if ($confirmation -ne "y") {
+        Write-Host "WARNING: No commits found between $previousTag and HEAD." -ForegroundColor Yellow
+        if (-not (Confirm-Continue -Prompt "Do you want to continue anyway?" -AllowYesContinue)) {
             Write-Host "Operation cancelled." -ForegroundColor Red
             exit 1
         }
     }
     else {
-        Write-Host "✅ Changelog generated successfully" -ForegroundColor Green
+        Write-Host "Changelog generated successfully" -ForegroundColor Green
         Write-Host "`nRaw Changelog:" -ForegroundColor Cyan
         Write-Host $changelog -ForegroundColor White
     }
@@ -197,47 +238,33 @@ function New-Changelog {
     return $changelog
 }
 
-function Update-ReleaseNotes {
+function Get-ReleaseNotesEntry {
     param (
         [string]$version,
         [string]$changelog
     )
 
-    Write-Host "`nUpdating release notes and VERSION file..." -ForegroundColor Cyan
+    $today = Get-Date -Format "yyyy-MM-dd"
 
-    # Update VERSION file (strip leading 'v' to match create-release.sh)
-    $versionWithoutV = $version -replace '^v', ''
-    $versionFilePath = Join-Path -Path $RootDir -ChildPath "VERSION"
-    if ($DryRun) {
-        Write-Host "🔍 [DRY RUN] Would update VERSION file to: $versionWithoutV" -ForegroundColor Cyan
-    }
-    else {
-        Set-Content -Path $versionFilePath -Value $versionWithoutV
-        Write-Host "✅ Updated VERSION file to: $versionWithoutV" -ForegroundColor Green
-    }
-
-    # Check if release notes file exists
-    if (-not (Test-Path -Path $ReleaseNotesPath)) {
-        Write-Host "❌ Release notes file not found at: $ReleaseNotesPath" -ForegroundColor Red
-        exit 1
-    }
-
-    # Read the release notes file
-    $releaseNotes = Get-Content -Path $ReleaseNotesPath -Raw
-
-    # Check if version already exists in release notes
-    if ($releaseNotes -match "### $version ") {
-        Write-Host "⚠️ WARNING: Version $version already exists in release notes." -ForegroundColor Yellow
-        $confirmation = Read-Host "Do you want to continue anyway? (y/n)"
-        if ($confirmation -ne "y") {
-            Write-Host "Operation cancelled." -ForegroundColor Red
+    if (-not [string]::IsNullOrWhiteSpace($NotesFile)) {
+        if (-not (Test-Path -Path $NotesFile)) {
+            Write-Host "Notes file not found: $NotesFile" -ForegroundColor Red
             exit 1
         }
+        $notesContent = (Get-Content -Path $NotesFile -Raw).TrimEnd()
+        if ($notesContent -match "(?m)^###\s+") {
+            return "`n$notesContent`n"
+        }
+        return @"
+
+### $version ($today)
+
+$notesContent
+
+"@
     }
 
-    # Prepare new release notes entry
-    $today = Get-Date -Format "yyyy-MM-dd"
-    $newEntry = @"
+    return @"
 
 ### $version ($today)
 
@@ -258,72 +285,117 @@ function Update-ReleaseNotes {
 $changelog
 
 "@
+}
 
-    # Find the position to insert the new entry (after "## Version History" section)
+function Update-VersionAndNotes {
+    param (
+        [string]$version,
+        [string]$changelog,
+        [switch]$CommitChanges
+    )
+
+    Write-Host "`nUpdating release notes and VERSION file..." -ForegroundColor Cyan
+
+    $versionWithoutV = $version -replace '^v', ''
+    if ($DryRun) {
+        Write-Host "[DRY RUN] Would update VERSION file to: $versionWithoutV" -ForegroundColor Cyan
+    }
+    else {
+        # VERSION file: single line, no extra blank line from Set-Content quirks on some hosts
+        [System.IO.File]::WriteAllText($VersionFilePath, "$versionWithoutV`n")
+        Write-Host "Updated VERSION file to: $versionWithoutV" -ForegroundColor Green
+    }
+
+    if ($SkipNotes) {
+        Write-Host "Skipping docs/release-notes.md update (-SkipNotes)." -ForegroundColor Yellow
+        if ($CommitChanges -and -not $DryRun) {
+            Write-Host "`nCommitting VERSION file..." -ForegroundColor Cyan
+            git add $VersionFilePath
+            git commit -m "chore(release): prepare $version"
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "Failed to commit VERSION." -ForegroundColor Red
+                exit 1
+            }
+            Write-Host "VERSION committed successfully" -ForegroundColor Green
+        }
+        elseif ($CommitChanges -and $DryRun) {
+            Write-Host "[DRY RUN] Would commit VERSION for $version" -ForegroundColor Cyan
+        }
+        return
+    }
+
+    if (-not (Test-Path -Path $ReleaseNotesPath)) {
+        Write-Host "Release notes file not found at: $ReleaseNotesPath" -ForegroundColor Red
+        exit 1
+    }
+
+    $releaseNotes = Get-Content -Path $ReleaseNotesPath -Raw
+    if ($releaseNotes -match "### $([regex]::Escape($version)) ") {
+        Write-Host "WARNING: Version $version already exists in release notes." -ForegroundColor Yellow
+        if (-not (Confirm-Continue -Prompt "Do you want to continue anyway?" -AllowYesContinue)) {
+            Write-Host "Operation cancelled." -ForegroundColor Red
+            exit 1
+        }
+    }
+
+    $newEntry = Get-ReleaseNotesEntry -version $version -changelog $changelog
+
     $versionHistoryIndex = $releaseNotes.IndexOf("## Version History")
     if ($versionHistoryIndex -eq -1) {
-        Write-Host "❌ Could not find '## Version History' section in release notes." -ForegroundColor Red
+        Write-Host "Could not find '## Version History' section in release notes." -ForegroundColor Red
         exit 1
     }
 
-    # Find the end of the "## Version History" line
     $insertPosition = $releaseNotes.IndexOf("`n", $versionHistoryIndex) + 1
     if ($insertPosition -le 0) {
-        Write-Host "❌ Could not determine where to insert new release entry." -ForegroundColor Red
+        Write-Host "Could not determine where to insert new release entry." -ForegroundColor Red
         exit 1
     }
 
-    # Insert the new entry
     $updatedReleaseNotes = $releaseNotes.Substring(0, $insertPosition) + $newEntry + $releaseNotes.Substring($insertPosition)
 
     if ($DryRun) {
-        Write-Host "🔍 [DRY RUN] Would create backup of release notes at: $ReleaseNotesPath.bak" -ForegroundColor Cyan
-        Write-Host "🔍 [DRY RUN] Would update release notes with new version $version" -ForegroundColor Cyan
-        Write-Host "🔍 [DRY RUN] Would commit the updated release notes and VERSION file" -ForegroundColor Cyan
-        Write-Host "`nPreview of release notes changes:" -ForegroundColor Yellow
+        Write-Host "[DRY RUN] Would update release notes with new version $version" -ForegroundColor Cyan
+        Write-Host "[DRY RUN] Would commit the updated release notes and VERSION file" -ForegroundColor Cyan
+        Write-Host "`nPreview of release notes entry:" -ForegroundColor Yellow
         Write-Host "=================================" -ForegroundColor Yellow
         Write-Host $newEntry -ForegroundColor White
         Write-Host "=================================`n" -ForegroundColor Yellow
         return
     }
 
-    # Create backup of current release notes
     $backupPath = "$ReleaseNotesPath.bak"
     Copy-Item -Path $ReleaseNotesPath -Destination $backupPath -Force
-    Write-Host "✅ Created backup of release notes at: $backupPath" -ForegroundColor Green
+    [System.IO.File]::WriteAllText($ReleaseNotesPath, $updatedReleaseNotes)
+    Write-Host "Updated release notes with new version $version" -ForegroundColor Green
 
-    # Write updated release notes to file
-    Set-Content -Path $ReleaseNotesPath -Value $updatedReleaseNotes
-    Write-Host "✅ Updated release notes with new version $version" -ForegroundColor Green
-    Write-Host "`n⚠️ IMPORTANT: Please review and edit the release notes manually before continuing." -ForegroundColor Yellow
-    Write-Host "The generated changelog has been added to the 'Technical Details' section." -ForegroundColor Yellow
-    Write-Host "You should categorize the changes into 'New Features', 'Bug Fixes', and 'Breaking Changes'." -ForegroundColor Yellow
-
-    $confirmation = Read-Host "Have you reviewed and edited the release notes? (y/n)"
-    if ($confirmation -ne "y") {
-        Write-Host "Please edit the release notes at: $ReleaseNotesPath" -ForegroundColor Cyan
-        Write-Host "Then run this script again with the -SkipNotes flag to continue." -ForegroundColor Cyan
-        exit 0
-    } else {
-        # Clean up backup file after confirmation
-        if (Test-Path -Path $backupPath) {
-            Remove-Item -Path $backupPath -Force
-            Write-Host "✅ Removed backup file after confirmation" -ForegroundColor Green
+    if (-not $Yes -and [string]::IsNullOrWhiteSpace($NotesFile)) {
+        Write-Host "`nIMPORTANT: Please review and edit the release notes before continuing." -ForegroundColor Yellow
+        Write-Host "Stub sections may need categorization; or pass -NotesFile / -Yes for agents." -ForegroundColor Yellow
+        if (-not (Confirm-Continue -Prompt "Have you reviewed and edited the release notes?")) {
+            Write-Host "Please edit the release notes at: $ReleaseNotesPath" -ForegroundColor Cyan
+            Write-Host "Then re-run with -SkipNotes (and -DirectTag if tagging) or provide -NotesFile -Yes." -ForegroundColor Cyan
+            exit 0
         }
+    }
 
-        # Commit the updated release notes and VERSION file (match create-release.sh)
+    if (Test-Path -Path $backupPath) {
+        Remove-Item -Path $backupPath -Force
+    }
+
+    if ($CommitChanges) {
         Write-Host "`nCommitting the updated release notes and VERSION file..." -ForegroundColor Cyan
-        git add $ReleaseNotesPath $versionFilePath
-        git commit -m "docs: update release notes and version for $version"
+        git add $ReleaseNotesPath $VersionFilePath
+        git commit -m "chore(release): prepare $version"
         if ($LASTEXITCODE -ne 0) {
-            Write-Host "⚠️ WARNING: Failed to commit the updated files." -ForegroundColor Yellow
-            $confirmation = Read-Host "Do you want to continue anyway? (y/n)"
-            if ($confirmation -ne "y") {
+            Write-Host "WARNING: Failed to commit the updated files." -ForegroundColor Yellow
+            if (-not (Confirm-Continue -Prompt "Do you want to continue anyway?")) {
                 Write-Host "Operation cancelled." -ForegroundColor Red
                 exit 1
             }
-        } else {
-            Write-Host "✅ Release notes and VERSION file committed successfully" -ForegroundColor Green
+        }
+        else {
+            Write-Host "Release notes and VERSION file committed successfully" -ForegroundColor Green
         }
     }
 }
@@ -336,63 +408,56 @@ function New-GitTag {
     Write-Host "`nCreating Git tag: $version..." -ForegroundColor Cyan
 
     if ($DryRun) {
-        Write-Host "🔍 [DRY RUN] Would create Git tag: $version" -ForegroundColor Cyan
-        Write-Host "🔍 [DRY RUN] Would push Git tag to remote" -ForegroundColor Cyan
+        Write-Host "[DRY RUN] Would create Git tag: $version" -ForegroundColor Cyan
+        Write-Host "[DRY RUN] Would push Git tag to remote" -ForegroundColor Cyan
         return
     }
 
-    # Check if tag already exists locally
     $existingTags = git tag -l $version
     if ($existingTags -contains $version) {
-        Write-Host "⚠️ WARNING: Tag $version already exists locally." -ForegroundColor Yellow
+        Write-Host "WARNING: Tag $version already exists locally." -ForegroundColor Yellow
 
-        # Refuse if the tag already exists on remote — we do not force-push tags
         $remoteTag = git ls-remote --tags origin "refs/tags/$version" 2>$null
         if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($remoteTag)) {
-            Write-Host "❌ Tag $version already exists on remote. Refusing to retag." -ForegroundColor Red
+            Write-Host "Tag $version already exists on remote. Refusing to retag." -ForegroundColor Red
             Write-Host "This script does not force-push tags. Delete the remote tag explicitly if you intend to replace it, then re-run." -ForegroundColor Yellow
             exit 1
         }
 
-        $confirmation = Read-Host "Do you want to replace the local tag and push it? (y/n)"
-        if ($confirmation -ne "y") {
+        if (-not (Confirm-Continue -Prompt "Do you want to replace the local tag and push it?")) {
             Write-Host "Operation cancelled." -ForegroundColor Red
             exit 1
         }
 
-        # Delete existing local tag only
         git tag -d $version
         if ($LASTEXITCODE -ne 0) {
-            Write-Host "❌ Failed to delete existing local tag." -ForegroundColor Red
+            Write-Host "Failed to delete existing local tag." -ForegroundColor Red
             exit 1
         }
     }
     else {
-        # Also refuse when remote has the tag even if local does not
         $remoteTag = git ls-remote --tags origin "refs/tags/$version" 2>$null
         if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($remoteTag)) {
-            Write-Host "❌ Tag $version already exists on remote. Refusing to retag." -ForegroundColor Red
+            Write-Host "Tag $version already exists on remote. Refusing to retag." -ForegroundColor Red
             Write-Host "This script does not force-push tags. Delete the remote tag explicitly if you intend to replace it, then re-run." -ForegroundColor Yellow
             exit 1
         }
     }
 
-    # Create the tag
     git tag -a $version -m "Release $version"
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "❌ Failed to create Git tag." -ForegroundColor Red
+        Write-Host "Failed to create Git tag." -ForegroundColor Red
         exit 1
     }
-    Write-Host "✅ Git tag created successfully" -ForegroundColor Green
+    Write-Host "Git tag created successfully" -ForegroundColor Green
 
-    # Push the tag (non-force)
     Write-Host "`nPushing Git tag to remote..." -ForegroundColor Cyan
     git push origin $version
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "❌ Failed to push Git tag to remote." -ForegroundColor Red
+        Write-Host "Failed to push Git tag to remote." -ForegroundColor Red
         exit 1
     }
-    Write-Host "✅ Git tag pushed successfully" -ForegroundColor Green
+    Write-Host "Git tag pushed successfully" -ForegroundColor Green
 }
 
 function Build-DockerImages {
@@ -402,21 +467,18 @@ function Build-DockerImages {
 
     Write-Host "`nChecking Docker availability..." -ForegroundColor Cyan
 
-    # Check if Docker is installed
     try {
         $null = docker --version
     }
     catch {
-        Write-Host "❌ Docker is not installed or not in PATH. Cannot build Docker images." -ForegroundColor Red
-        $confirmation = Read-Host "Do you want to continue without building Docker images? (y/n)"
-        if ($confirmation -ne "y") {
+        Write-Host "Docker is not installed or not in PATH. Cannot build Docker images." -ForegroundColor Red
+        if (-not (Confirm-Continue -Prompt "Do you want to continue without building Docker images?" -AllowYesContinue)) {
             Write-Host "Operation cancelled." -ForegroundColor Red
             exit 1
         }
         return
     }
 
-    # Check if Docker is running
     try {
         $null = docker info
         if ($LASTEXITCODE -ne 0) {
@@ -424,9 +486,8 @@ function Build-DockerImages {
         }
     }
     catch {
-        Write-Host "❌ Docker engine is not running. Cannot build Docker images." -ForegroundColor Red
-        $confirmation = Read-Host "Do you want to continue without building Docker images? (y/n)"
-        if ($confirmation -ne "y") {
+        Write-Host "Docker engine is not running. Cannot build Docker images." -ForegroundColor Red
+        if (-not (Confirm-Continue -Prompt "Do you want to continue without building Docker images?" -AllowYesContinue)) {
             Write-Host "Operation cancelled." -ForegroundColor Red
             exit 1
         }
@@ -436,119 +497,238 @@ function Build-DockerImages {
     Write-Host "`nBuilding and pushing Docker images..." -ForegroundColor Cyan
 
     if ($DryRun) {
-        Write-Host "🔍 [DRY RUN] Would build and push Docker images with tag: $version" -ForegroundColor Cyan
-        Write-Host "🔍 [DRY RUN] Would execute: $DockerBuildScript -Tag $version" -ForegroundColor Cyan
+        Write-Host "[DRY RUN] Would build and push Docker images with tag: $version" -ForegroundColor Cyan
+        Write-Host "[DRY RUN] Would execute: $DockerBuildScript -Tag $version" -ForegroundColor Cyan
         return
     }
 
-    # Check if build script exists
     if (-not (Test-Path -Path $DockerBuildScript)) {
-        Write-Host "❌ Docker build script not found at: $DockerBuildScript" -ForegroundColor Red
-        $confirmation = Read-Host "Do you want to continue without building Docker images? (y/n)"
-        if ($confirmation -ne "y") {
+        Write-Host "Docker build script not found at: $DockerBuildScript" -ForegroundColor Red
+        if (-not (Confirm-Continue -Prompt "Do you want to continue without building Docker images?" -AllowYesContinue)) {
             Write-Host "Operation cancelled." -ForegroundColor Red
             exit 1
         }
         return
     }
 
-    # Run the build script
     Write-Host "Running Docker build script with tag: $version" -ForegroundColor Cyan
     & $DockerBuildScript -Tag $version
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "❌ Docker build script failed." -ForegroundColor Red
-        $confirmation = Read-Host "Do you want to continue anyway? (y/n)"
-        if ($confirmation -ne "y") {
+        Write-Host "Docker build script failed." -ForegroundColor Red
+        if (-not (Confirm-Continue -Prompt "Do you want to continue anyway?")) {
             Write-Host "Operation cancelled." -ForegroundColor Red
             exit 1
         }
     }
     else {
-        Write-Host "✅ Docker images built and pushed successfully" -ForegroundColor Green
+        Write-Host "Docker images built and pushed successfully" -ForegroundColor Green
     }
 }
 
-# Main execution flow
+function Invoke-ReleasePrMode {
+    param (
+        [string]$version,
+        [string]$changelog
+    )
+
+    $releaseBranch = "release/$version"
+    Write-Host "`nRelease PR mode (default). Branch SSOT: $releaseBranch" -ForegroundColor Cyan
+
+    if ($BuildDocker) {
+        Write-Host "WARNING: -BuildDocker is ignored in Release PR mode (images publish after tag on merge)." -ForegroundColor Yellow
+    }
+
+    if ($DryRun) {
+        Write-Host "[DRY RUN] Would create branch: $releaseBranch" -ForegroundColor Cyan
+        Update-VersionAndNotes -version $version -changelog $changelog -CommitChanges
+        Write-Host "[DRY RUN] Would push $releaseBranch and run: gh pr create --base main --head $releaseBranch" -ForegroundColor Cyan
+        Write-Host "[DRY RUN] Would print the PR URL" -ForegroundColor Cyan
+        return
+    }
+
+    # Refuse early if remote tag already exists
+    $remoteTag = git ls-remote --tags origin "refs/tags/$version" 2>$null
+    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($remoteTag)) {
+        Write-Host "Tag $version already exists on remote. Refusing to open a Release PR for it." -ForegroundColor Red
+        Write-Host "This script does not force-push tags." -ForegroundColor Yellow
+        exit 1
+    }
+
+    $existingBranch = git branch --list $releaseBranch
+    if ($existingBranch) {
+        Write-Host "Local branch $releaseBranch already exists." -ForegroundColor Red
+        exit 1
+    }
+
+    $remoteBranch = git ls-remote --heads origin $releaseBranch 2>$null
+    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($remoteBranch)) {
+        Write-Host "Remote branch $releaseBranch already exists." -ForegroundColor Red
+        exit 1
+    }
+
+    if (-not (Test-GhAvailable)) {
+        Write-Host "GitHub CLI (gh) is required for Release PR mode. Install gh or use -DirectTag (discouraged)." -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Creating branch $releaseBranch..." -ForegroundColor Cyan
+    git checkout -b $releaseBranch
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Failed to create branch $releaseBranch." -ForegroundColor Red
+        exit 1
+    }
+
+    Update-VersionAndNotes -version $version -changelog $changelog -CommitChanges
+
+    Write-Host "`nPushing branch $releaseBranch..." -ForegroundColor Cyan
+    git push -u origin $releaseBranch
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Failed to push branch $releaseBranch." -ForegroundColor Red
+        exit 1
+    }
+
+    $prBody = @"
+## Summary
+- Prepare release **$version** (branch ``$releaseBranch`` is version SSOT).
+- Updates ``VERSION`` and ``docs/release-notes.md``.
+
+## After merge
+- Tagging / GitHub Release should be created by CI (release-tag-on-merge).
+- Docker Hub images publish from the ``v*`` tag via Docker Publish.
+
+## Test plan
+- [ ] Release notes look correct
+- [ ] VERSION matches branch (without leading ``v``)
+- [ ] CI green before merge
+"@
+
+    Write-Host "`nCreating pull request..." -ForegroundColor Cyan
+    $prUrl = gh pr create --base main --head $releaseBranch --title "chore(release): $version" --body $prBody
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Failed to create pull request." -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "`nRelease PR created:" -ForegroundColor Green
+    Write-Host $prUrl -ForegroundColor White
+    Write-Host "`nMerge the PR to cut the release. Monitor: $RepoActionsUrl" -ForegroundColor Yellow
+}
+
+function Invoke-DirectTagMode {
+    param (
+        [string]$version,
+        [string]$changelog
+    )
+
+    Write-Host "`nWARNING: -DirectTag is an emergency path (tags from main, no Release PR)." -ForegroundColor Yellow
+
+    Update-VersionAndNotes -version $version -changelog $changelog -CommitChanges
+
+    if ($DryRun) {
+        Write-Host "[DRY RUN] Would push main after notes/VERSION commit" -ForegroundColor Cyan
+    }
+    else {
+        Write-Host "`nPushing main (release notes / VERSION commit)..." -ForegroundColor Cyan
+        git push origin main
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Failed to push main. Tag will not be created until main is pushed." -ForegroundColor Red
+            exit 1
+        }
+    }
+
+    New-GitTag -version $version
+
+    if ($BuildDocker) {
+        Build-DockerImages -version $version
+    }
+    else {
+        Write-Host "`nSkipping Docker build (use -BuildDocker with -DirectTag to build images locally)." -ForegroundColor Yellow
+    }
+
+    if ($DryRun) {
+        Write-Host "`nDry run completed for direct-tag path: $version" -ForegroundColor Green
+    }
+    else {
+        Write-Host "`nDirect-tag release completed for: $version" -ForegroundColor Green
+        Write-Host "Next steps:" -ForegroundColor Yellow
+        Write-Host "  1. Monitor GitHub Actions: $RepoActionsUrl" -ForegroundColor White
+        Write-Host "  2. Verify Docker images on Docker Hub" -ForegroundColor White
+    }
+}
+
+function Clear-ChangelogArtifact {
+    if (Test-Path -Path $ChangelogPath) {
+        if ($DryRun) {
+            Write-Host "[DRY RUN] Would clean up temporary files (changelog.txt left in place)" -ForegroundColor Cyan
+        }
+        else {
+            Remove-Item -Path $ChangelogPath -Force
+            Write-Host "Removed temporary changelog file" -ForegroundColor Green
+        }
+    }
+}
+
+# --- main ---
 if ($Help) {
     Show-Help
     exit 0
 }
 
 if ([string]::IsNullOrEmpty($Version)) {
-    Write-Host "❌ Version parameter is required. Use -Version to specify the version to release." -ForegroundColor Red
+    Write-Host "Version parameter is required. Use -Version to specify the version to release." -ForegroundColor Red
     Show-Help
     exit 1
 }
 
-# Validate version format
 if (-not ($Version -match '^v\d+\.\d+\.\d+(-[a-zA-Z0-9\.]+)?$')) {
-    Write-Host "❌ Invalid version format. Version should be in the format 'vX.Y.Z' or 'vX.Y.Z-suffix'" -ForegroundColor Red
+    Write-Host "Invalid version format. Use 'vX.Y.Z' or 'vX.Y.Z-suffix'." -ForegroundColor Red
     Write-Host "Examples: v1.0.0, v0.1.0-beta.1, v2.0.0-rc.3" -ForegroundColor Cyan
     exit 1
 }
 
-# Check if Git is available
 if (-not (Test-GitAvailable)) {
-    Write-Host "❌ Git is not available. Please install Git and try again." -ForegroundColor Red
+    Write-Host "Git is not available. Please install Git and try again." -ForegroundColor Red
     exit 1
 }
 
-# Get previous tag if not specified
 if ([string]::IsNullOrEmpty($PreviousTag)) {
     $PreviousTag = Get-LatestGitTag
 }
 
-# Start the release process
-if ($DryRun) {
-    Write-Host "`n🔍 [DRY RUN] Starting release process simulation for version: $Version" -ForegroundColor Cyan
-    Write-Host "🔍 No actual changes will be made to files or repositories." -ForegroundColor Cyan
-} else {
-    Write-Host "`n🚀 Starting release process for version: $Version" -ForegroundColor Green
-}
-
-# Confirm and prepare main branch
-Confirm-MainBranch
-
-# Generate changelog
-$changelog = New-Changelog -previousTag $PreviousTag -currentTag $Version
-
-# Update release notes
-if (-not $SkipNotes) {
-    Update-ReleaseNotes -version $Version -changelog $changelog
-}
-else {
-    Write-Host "`n⚠️ Skipping release notes update as requested." -ForegroundColor Yellow
-}
-
-# Create and push Git tag
-New-GitTag -version $Version
-
-# Build and push Docker images (only if -BuildDocker is specified)
-if ($BuildDocker) {
-    Build-DockerImages -version $Version
-}
-else {
-    Write-Host "`n⚠️ Skipping Docker build (use -BuildDocker flag to build images)." -ForegroundColor Yellow
-}
-
-# Clean up temporary files
-if (Test-Path -Path $ChangelogPath) {
+Push-Location $RootDir
+try {
     if ($DryRun) {
-        Write-Host "🔍 [DRY RUN] Would clean up temporary files" -ForegroundColor Cyan
-    } else {
-        Remove-Item -Path $ChangelogPath -Force
-        Write-Host "✅ Removed temporary changelog file" -ForegroundColor Green
+        Write-Host "`n[DRY RUN] Starting release simulation for version: $Version" -ForegroundColor Cyan
+        if ($DirectTag) {
+            Write-Host "[DRY RUN] Mode: DirectTag (emergency)" -ForegroundColor Cyan
+        }
+        else {
+            Write-Host "[DRY RUN] Mode: Release PR (default)" -ForegroundColor Cyan
+        }
     }
-}
+    else {
+        Write-Host "`nStarting release process for version: $Version" -ForegroundColor Green
+        if ($DirectTag) {
+            Write-Host "Mode: DirectTag (emergency)" -ForegroundColor Yellow
+        }
+        else {
+            Write-Host "Mode: Release PR (default)" -ForegroundColor Green
+        }
+    }
 
-if ($DryRun) {
-    Write-Host "`n✅ Dry run completed successfully for version: $Version" -ForegroundColor Green
-    Write-Host "No actual changes were made. Run without -DryRun to execute the release process." -ForegroundColor Cyan
-} else {
-    Write-Host "`n✅ Release process completed successfully for version: $Version" -ForegroundColor Green
-    Write-Host "`n📋 Next steps:" -ForegroundColor Yellow
-    Write-Host "  1. Monitor GitHub Actions workflow at: https://github.com/mnaimfaizy/fastapi_rbac/actions" -ForegroundColor White
-    Write-Host "  2. Verify Docker images on Docker Hub" -ForegroundColor White
-    Write-Host "  3. Notify team members about the new release" -ForegroundColor White
+    Assert-MainClean -PullMain
+    $changelog = New-Changelog -previousTag $PreviousTag -currentTag $Version
+
+    if ($DirectTag) {
+        Invoke-DirectTagMode -version $Version -changelog $changelog
+    }
+    else {
+        Invoke-ReleasePrMode -version $Version -changelog $changelog
+    }
+
+    Clear-ChangelogArtifact
+    Write-Host "`nThank you for using the FastAPI RBAC Release Automation Script!" -ForegroundColor Cyan
 }
-Write-Host "`nThank you for using the FastAPI RBAC Release Automation Script! 🎉" -ForegroundColor Cyan
+finally {
+    Pop-Location
+}

--- a/scripts/deployment/release/create-release.sh
+++ b/scripts/deployment/release/create-release.sh
@@ -1,32 +1,30 @@
 #!/bin/bash
 # create-release.sh - FastAPI RBAC Release Automation Script
 #
-# This script automates the release process for the FastAPI RBAC project by:
-# 1. Generating a changelog from Git history
-# 2. Updating VERSION (strip leading v) and docs/release-notes.md
-# 3. Creating and pushing a Git tag
-# 4. Optionally building and pushing Docker images
-#
-# Kept in parity with Create-Release.ps1 (Phase B / issue #84).
+# Default: Release PR mode (branch release/vX.Y.Z, VERSION + notes, push, gh pr create).
+# Emergency: --direct-tag tags from main (discouraged).
+# Kept in parity with Create-Release.ps1 (Phase C1).
 #
 # Author: FastAPI RBAC Team
 # Created: July 2, 2025
 
 set -e
 
-# Default values
 SKIP_NOTES=false
 BUILD_DOCKER=false
 DRY_RUN=false
+DIRECT_TAG=false
+YES=false
+NOTES_FILE=""
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../../../" && pwd)"
 RELEASE_NOTES_PATH="$ROOT_DIR/docs/release-notes.md"
 CHANGELOG_PATH="$ROOT_DIR/changelog.txt"
+VERSION_FILE_PATH="$ROOT_DIR/VERSION"
 DOCKER_BUILD_SCRIPT="$ROOT_DIR/scripts/deployment/production/build-and-push.sh"
+REPO_ACTIONS_URL="https://github.com/mnaimfaizy/fastapi_rbac/actions"
 
-# Add a trap to ensure we clean up the changelog file even on error
 cleanup() {
-    # Only clean up if not in dry run mode
     if [ "$DRY_RUN" != true ] && [ -f "$CHANGELOG_PATH" ]; then
         echo -e "\nCleaning up changelog file after error..."
         rm -f "$CHANGELOG_PATH"
@@ -34,185 +32,199 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# ANSI color codes
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 CYAN='\033[0;36m'
 WHITE='\033[1;37m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
 function show_help {
-    echo -e "${CYAN}\n🚀 FastAPI RBAC Release Automation Script"
-    echo -e "===========================================${NC}"
-    echo -e "\nThis script automates the release process for the FastAPI RBAC project.\n"
+    echo -e "${CYAN}\nFastAPI RBAC Release Automation Script"
+    echo -e "======================================${NC}"
+    echo -e "\nDefault mode opens a Release PR (release/vX.Y.Z). Use --direct-tag only for emergencies.\n"
 
-    echo -e "${YELLOW}📋 Parameters:${NC}"
-    echo -e "${WHITE}  -v, --version VERSION   : Version to release (e.g., v1.0.0, v0.1.0-beta.1)${NC}"
-    echo -e "${WHITE}  -p, --previous-tag TAG  : Previous tag to generate changelog from (defaults to latest tag)${NC}"
-    echo -e "${WHITE}  -s, --skip-notes        : Skip updating release notes (just create and push tag)${NC}"
-    echo -e "${WHITE}  -b, --build-docker      : Build and push Docker images (opt-in)${NC}"
-    echo -e "${WHITE}  -r, --dry-run           : Simulate the release process without making actual changes${NC}"
-    echo -e "${WHITE}  -h, --help              : Show this help message${NC}"
+    echo -e "${YELLOW}Parameters:${NC}"
+    echo -e "${WHITE}  -v, --version VERSION     : Version to release (required)${NC}"
+    echo -e "${WHITE}  -p, --previous-tag TAG    : Previous tag for changelog (default: latest)${NC}"
+    echo -e "${WHITE}  -n, --notes-file PATH     : Release-notes section to insert${NC}"
+    echo -e "${WHITE}  -s, --skip-notes          : Skip docs/release-notes.md (still updates VERSION in PR mode)${NC}"
+    echo -e "${WHITE}      --direct-tag          : EMERGENCY — tag from main (skips Release PR)${NC}"
+    echo -e "${WHITE}  -y, --yes                 : Non-interactive (fail closed on unsafe warnings)${NC}"
+    echo -e "${WHITE}  -b, --build-docker        : Local image build (DirectTag only)${NC}"
+    echo -e "${WHITE}  -r, --dry-run             : Simulate without mutating remotes/release files${NC}"
+    echo -e "${WHITE}  -h, --help                : Show this help${NC}"
 
-    echo -e "\n${YELLOW}💡 Examples:${NC}"
-    echo -e "${WHITE}  ./create-release.sh -v v1.0.0${NC}"
-    echo -e "${WHITE}  ./create-release.sh -v v1.0.0 -p v0.9.0${NC}"
-    echo -e "${WHITE}  ./create-release.sh -v v1.0.0 --skip-notes${NC}"
-    echo -e "${WHITE}  ./create-release.sh -v v1.0.0 --build-docker${NC}"
+    echo -e "\n${YELLOW}Examples:${NC}"
+    echo -e "${WHITE}  ./create-release.sh -v v1.0.0 --yes${NC}"
+    echo -e "${WHITE}  ./create-release.sh -v v1.0.0 --notes-file ./notes-section.md --yes${NC}"
     echo -e "${WHITE}  ./create-release.sh -v v1.0.0 --dry-run${NC}"
+    echo -e "${WHITE}  ./create-release.sh -v v1.0.0 --direct-tag --yes   # discouraged${NC}"
 
-    echo -e "\n${YELLOW}📝 Process:${NC}"
-    echo -e "${WHITE}  1. Generate changelog from Git history${NC}"
-    echo -e "${WHITE}  2. Update VERSION (strip leading v) and docs/release-notes.md${NC}"
-    echo -e "${WHITE}  3. Create and push Git tag${NC}"
-    echo -e "${WHITE}  4. Optionally build and push Docker images (with -b/--build-docker flag)${NC}"
+    echo -e "\n${YELLOW}Default process (Release PR):${NC}"
+    echo -e "${WHITE}  1. Ensure main is clean and up to date${NC}"
+    echo -e "${WHITE}  2. Create branch release/<version> (branch name is version SSOT)${NC}"
+    echo -e "${WHITE}  3. Update VERSION + docs/release-notes.md and commit${NC}"
+    echo -e "${WHITE}  4. Push branch and open PR with gh; print PR URL${NC}"
+    echo -e "${WHITE}  5. After merge, CI creates the tag / GitHub Release (Phase C2+)${NC}"
 
-    echo -e "\n${YELLOW}🔍 Dry-run notes:${NC}"
-    echo -e "${WHITE}  • Does not pull origin/main, write release notes/VERSION, commit, tag, or push${NC}"
-    echo -e "${WHITE}  • Still writes temporary changelog.txt (left in place after dry-run)${NC}"
-    echo -e "${WHITE}  • Still requires interactive confirmations for warnings${NC}"
-
-    echo -e "\n${YELLOW}🔧 Requirements:${NC}"
-    echo -e "${WHITE}  • Git installed and configured${NC}"
-    echo -e "${WHITE}  • Access to the repository${NC}"
-    echo -e "${WHITE}  • Docker installed and running (if using -b/--build-docker)${NC}"
+    echo -e "\n${YELLOW}Dry-run notes:${NC}"
+    echo -e "${WHITE}  • Skips git pull, file writes, commit, push, tag, and gh pr create${NC}"
+    echo -e "${WHITE}  • Still writes temporary changelog.txt (left in place)${NC}"
     echo ""
 }
 
 function test_git_available {
     if ! command -v git &> /dev/null; then
-        echo -e "${RED}❌ Git is not available. Please install Git and try again.${NC}"
+        echo -e "${RED}Git is not available. Please install Git and try again.${NC}"
         exit 1
     fi
+}
+
+function test_gh_available {
+    if ! command -v gh &> /dev/null; then
+        return 1
+    fi
+    return 0
 }
 
 function get_latest_git_tag {
     if ! git describe --tags --abbrev=0 2>/dev/null; then
-        echo -e "${YELLOW}No previous tags found. This appears to be the first release.${NC}"
+        echo -e "${YELLOW}No previous tags found. This appears to be the first release.${NC}" >&2
         return 1
     fi
 }
 
-function confirm_main_branch {
+# confirm_continue "prompt" [allow_yes_continue]
+# allow_yes_continue=1 means -y continues; otherwise -y fails closed
+function confirm_continue {
+    local prompt="$1"
+    local allow_yes_continue="${2:-0}"
+
+    if [ "$YES" = true ]; then
+        if [ "$allow_yes_continue" = "1" ]; then
+            echo -e "${YELLOW}Continuing (--yes): $prompt${NC}"
+            return 0
+        fi
+        echo -e "${RED}Non-interactive (--yes): refusing to continue without confirmation.${NC}"
+        echo -e "${YELLOW}  $prompt${NC}"
+        exit 1
+    fi
+
+    local confirmation
+    read -p "$prompt (y/n): " confirmation
+    if [ "$confirmation" = "y" ]; then
+        return 0
+    fi
+    return 1
+}
+
+function assert_main_clean {
+    local pull_main="${1:-1}"
     local current_branch
     current_branch=$(git rev-parse --abbrev-ref HEAD)
+
     if [ "$current_branch" != "main" ]; then
-        echo -e "${YELLOW}⚠️ WARNING: You are not on the 'main' branch. Current branch: $current_branch${NC}"
-        read -p "Do you want to continue anyway? (y/n): " confirmation
-        if [ "$confirmation" != "y" ]; then
+        echo -e "${YELLOW}WARNING: You are not on the 'main' branch. Current branch: $current_branch${NC}"
+        if [ "$YES" = true ]; then
+            echo -e "${RED}Non-interactive (--yes): must start from main.${NC}"
+            exit 1
+        fi
+        if ! confirm_continue "Do you want to continue anyway?"; then
             echo -e "${RED}Operation cancelled. Please switch to the main branch and try again.${NC}"
             exit 1
         fi
     else
-        echo -e "${GREEN}✅ Current branch is 'main'${NC}"
+        echo -e "${GREEN}Current branch is 'main'${NC}"
     fi
 
-    # Check for uncommitted changes
     if [ -n "$(git status --porcelain)" ]; then
-        echo -e "${YELLOW}⚠️ WARNING: You have uncommitted changes in your working directory.${NC}"
-        read -p "Do you want to continue anyway? (y/n): " confirmation
-        if [ "$confirmation" != "y" ]; then
+        echo -e "${YELLOW}WARNING: You have uncommitted changes in your working directory.${NC}"
+        if [ "$YES" = true ]; then
+            echo -e "${RED}Non-interactive (--yes): working tree must be clean.${NC}"
+            exit 1
+        fi
+        if ! confirm_continue "Do you want to continue anyway?"; then
             echo -e "${RED}Operation cancelled. Please commit or stash your changes and try again.${NC}"
             exit 1
         fi
     else
-        echo -e "${GREEN}✅ Working directory is clean${NC}"
+        echo -e "${GREEN}Working directory is clean${NC}"
     fi
 
-    # Pull latest changes (skipped in dry-run so the simulation stays non-mutating)
+    if [ "$pull_main" != "1" ]; then
+        return 0
+    fi
+
     if [ "$DRY_RUN" = true ]; then
-        echo -e "${CYAN}🔍 [DRY RUN] Skipping git pull origin main${NC}"
-        return
+        echo -e "${CYAN}[DRY RUN] Skipping git pull origin main${NC}"
+        return 0
     fi
 
     echo -e "${CYAN}Pulling latest changes from origin/main...${NC}"
     if ! git pull origin main; then
-        echo -e "${RED}❌ Failed to pull latest changes. Please resolve any conflicts and try again.${NC}"
+        echo -e "${RED}Failed to pull latest changes. Please resolve any conflicts and try again.${NC}"
         exit 1
     fi
-    echo -e "${GREEN}✅ Successfully pulled latest changes${NC}"
+    echo -e "${GREEN}Successfully pulled latest changes${NC}"
 }
 
 function generate_changelog {
     local previous_tag="$1"
-    local current_tag="$2"
 
-    echo -e "${CYAN}Generating changelog from Git history...${NC}"
+    echo -e "${CYAN}Generating changelog from Git history...${NC}" >&2
 
-    # Clean up any existing changelog file
     if [ -f "$CHANGELOG_PATH" ]; then
         rm -f "$CHANGELOG_PATH"
-        echo -e "${CYAN}Removed existing changelog file${NC}"
+        echo -e "${CYAN}Removed existing changelog file${NC}" >&2
     fi
 
     if [ -z "$previous_tag" ]; then
-        # If this is the first release, get all commits
         git log --pretty=format:"- %s" > "$CHANGELOG_PATH"
     else
-        # Get commits between tags
         git log "${previous_tag}..HEAD" --pretty=format:"- %s" > "$CHANGELOG_PATH"
     fi
 
-    if [ $? -ne 0 ]; then
-        echo -e "${RED}❌ Failed to generate changelog.${NC}"
-        exit 1
-    fi
-
-    # Read the changelog
     local changelog
     changelog=$(cat "$CHANGELOG_PATH")
     if [ -z "$changelog" ]; then
-        echo -e "${YELLOW}⚠️ WARNING: No commits found between $previous_tag and HEAD.${NC}"
-        read -p "Do you want to continue anyway? (y/n): " confirmation
-        if [ "$confirmation" != "y" ]; then
-            echo -e "${RED}Operation cancelled.${NC}"
+        echo -e "${YELLOW}WARNING: No commits found between $previous_tag and HEAD.${NC}" >&2
+        if ! confirm_continue "Do you want to continue anyway?" 1; then
+            echo -e "${RED}Operation cancelled.${NC}" >&2
             exit 1
         fi
     else
-        echo -e "${GREEN}✅ Changelog generated successfully${NC}"
-        echo -e "${CYAN}\nRaw Changelog:${NC}"
-        echo -e "${WHITE}$changelog${NC}"
+        echo -e "${GREEN}Changelog generated successfully${NC}" >&2
+        echo -e "${CYAN}\nRaw Changelog:${NC}" >&2
+        echo -e "${WHITE}$changelog${NC}" >&2
     fi
 
-    echo "$changelog"
+    printf '%s' "$changelog"
 }
 
-function update_release_notes {
+function build_release_notes_entry {
     local version="$1"
     local changelog="$2"
-
-    echo -e "\n${CYAN}Updating release notes and VERSION file...${NC}"
-
-    # Update VERSION file
-    local version_without_v="${version#v}"  # Remove 'v' prefix if present
-    if [ "$DRY_RUN" = true ]; then
-        echo -e "${CYAN}🔍 [DRY RUN] Would update VERSION file to: $version_without_v${NC}"
-    else
-        echo "$version_without_v" > "$ROOT_DIR/VERSION"
-        echo -e "${GREEN}✅ Updated VERSION file to: $version_without_v${NC}"
-    fi
-
-    # Check if release notes file exists
-    if [ ! -f "$RELEASE_NOTES_PATH" ]; then
-        echo -e "${RED}❌ Release notes file not found at: $RELEASE_NOTES_PATH${NC}"
-        exit 1
-    fi
-
-    # Check if version already exists in release notes
-    if grep -q "### $version " "$RELEASE_NOTES_PATH"; then
-        echo -e "${YELLOW}⚠️ WARNING: Version $version already exists in release notes.${NC}"
-        read -p "Do you want to continue anyway? (y/n): " confirmation
-        if [ "$confirmation" != "y" ]; then
-            echo -e "${RED}Operation cancelled.${NC}"
-            exit 1
-        fi
-    fi
-
-    # Prepare new release notes entry
     local today
     today=$(date +%Y-%m-%d)
-    local new_entry="
+
+    if [ -n "$NOTES_FILE" ]; then
+        if [ ! -f "$NOTES_FILE" ]; then
+            echo -e "${RED}Notes file not found: $NOTES_FILE${NC}" >&2
+            exit 1
+        fi
+        local notes_content
+        notes_content=$(cat "$NOTES_FILE")
+        if echo "$notes_content" | grep -qE '^###[[:space:]]'; then
+            printf '\n%s\n' "$notes_content"
+            return 0
+        fi
+        printf '\n### %s (%s)\n\n%s\n' "$version" "$today" "$notes_content"
+        return 0
+    fi
+
+    cat <<EOF
+
 ### $version ($today)
 
 **New Features:**
@@ -230,74 +242,109 @@ function update_release_notes {
 **Technical Details:**
 
 $changelog
-"
 
-    # Find the position to insert the new entry (after "## Version History" section)
-    local version_history_line
-    version_history_line=$(grep -n "^## Version History" "$RELEASE_NOTES_PATH" | cut -d: -f1)
-    if [ -z "$version_history_line" ]; then
-        echo -e "${RED}❌ Could not find '## Version History' section in release notes.${NC}"
+EOF
+}
+
+function update_version_and_notes {
+    local version="$1"
+    local changelog="$2"
+    local commit_changes="$3"
+    local version_without_v="${version#v}"
+
+    echo -e "\n${CYAN}Updating release notes and VERSION file...${NC}"
+
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${CYAN}[DRY RUN] Would update VERSION file to: $version_without_v${NC}"
+    else
+        printf '%s\n' "$version_without_v" > "$VERSION_FILE_PATH"
+        echo -e "${GREEN}Updated VERSION file to: $version_without_v${NC}"
+    fi
+
+    if [ "$SKIP_NOTES" = true ]; then
+        echo -e "${YELLOW}Skipping docs/release-notes.md update (--skip-notes).${NC}"
+        if [ "$commit_changes" = true ] && [ "$DRY_RUN" != true ]; then
+            echo -e "\n${CYAN}Committing VERSION file...${NC}"
+            git add "$VERSION_FILE_PATH"
+            if ! git commit -m "chore(release): prepare $version"; then
+                echo -e "${RED}Failed to commit VERSION.${NC}"
+                exit 1
+            fi
+            echo -e "${GREEN}VERSION committed successfully${NC}"
+        elif [ "$commit_changes" = true ] && [ "$DRY_RUN" = true ]; then
+            echo -e "${CYAN}[DRY RUN] Would commit VERSION for $version${NC}"
+        fi
+        return 0
+    fi
+
+    if [ ! -f "$RELEASE_NOTES_PATH" ]; then
+        echo -e "${RED}Release notes file not found at: $RELEASE_NOTES_PATH${NC}"
         exit 1
     fi
 
-    # Create temporary file for updated release notes
+    if grep -q "### $version " "$RELEASE_NOTES_PATH"; then
+        echo -e "${YELLOW}WARNING: Version $version already exists in release notes.${NC}"
+        if ! confirm_continue "Do you want to continue anyway?" 1; then
+            echo -e "${RED}Operation cancelled.${NC}"
+            exit 1
+        fi
+    fi
+
+    local new_entry
+    new_entry=$(build_release_notes_entry "$version" "$changelog")
+
+    local version_history_line
+    version_history_line=$(grep -n "^## Version History" "$RELEASE_NOTES_PATH" | cut -d: -f1)
+    if [ -z "$version_history_line" ]; then
+        echo -e "${RED}Could not find '## Version History' section in release notes.${NC}"
+        exit 1
+    fi
+
     local tmp_file
     tmp_file=$(mktemp)
-
-    # Insert the new entry after the "## Version History" line
     awk -v line="$version_history_line" -v entry="$new_entry" '
         NR == line {print $0; print entry; next}
         {print}
     ' "$RELEASE_NOTES_PATH" > "$tmp_file"
 
     if [ "$DRY_RUN" = true ]; then
-        echo -e "${CYAN}🔍 [DRY RUN] Would create backup of release notes at: ${RELEASE_NOTES_PATH}.bak${NC}"
-        echo -e "${CYAN}🔍 [DRY RUN] Would update release notes with new version $version${NC}"
-        echo -e "${CYAN}🔍 [DRY RUN] Would commit the updated release notes${NC}"
-        echo -e "\n${YELLOW}Preview of release notes changes:${NC}"
+        echo -e "${CYAN}[DRY RUN] Would update release notes with new version $version${NC}"
+        echo -e "${CYAN}[DRY RUN] Would commit the updated release notes and VERSION file${NC}"
+        echo -e "\n${YELLOW}Preview of release notes entry:${NC}"
         echo -e "=================================${NC}"
-        cat "$tmp_file" | grep -A 20 "$version" | head -n 20
-        echo -e "...\n=================================${NC}"
+        echo "$new_entry"
+        echo -e "=================================${NC}"
         rm -f "$tmp_file"
-        return
+        return 0
     fi
 
-    # Create backup of current release notes
     cp "$RELEASE_NOTES_PATH" "${RELEASE_NOTES_PATH}.bak"
-    echo -e "${GREEN}✅ Created backup of release notes at: ${RELEASE_NOTES_PATH}.bak${NC}"
-
-    # Replace original file with updated content
     mv "$tmp_file" "$RELEASE_NOTES_PATH"
-    echo -e "${GREEN}✅ Updated release notes with new version $version${NC}"
+    echo -e "${GREEN}Updated release notes with new version $version${NC}"
 
-    echo -e "\n${YELLOW}⚠️ IMPORTANT: Please review and edit the release notes manually before continuing.${NC}"
-    echo -e "${YELLOW}The generated changelog has been added to the 'Technical Details' section.${NC}"
-    echo -e "${YELLOW}You should categorize the changes into 'New Features', 'Bug Fixes', and 'Breaking Changes'.${NC}"
-
-    read -p "Have you reviewed and edited the release notes? (y/n): " confirmation
-    if [ "$confirmation" != "y" ]; then
-        echo -e "${CYAN}Please edit the release notes at: $RELEASE_NOTES_PATH${NC}"
-        echo -e "${CYAN}Then run this script again with the --skip-notes flag to continue.${NC}"
-        exit 0
-    else
-        # Clean up backup file after confirmation
-        if [ -f "${RELEASE_NOTES_PATH}.bak" ]; then
-            rm -f "${RELEASE_NOTES_PATH}.bak"
-            echo -e "${GREEN}✅ Removed backup file after confirmation${NC}"
+    if [ "$YES" != true ] && [ -z "$NOTES_FILE" ]; then
+        echo -e "\n${YELLOW}IMPORTANT: Please review and edit the release notes before continuing.${NC}"
+        echo -e "${YELLOW}Stub sections may need categorization; or pass --notes-file / --yes for agents.${NC}"
+        if ! confirm_continue "Have you reviewed and edited the release notes?"; then
+            echo -e "${CYAN}Please edit the release notes at: $RELEASE_NOTES_PATH${NC}"
+            echo -e "${CYAN}Then re-run with --skip-notes or provide --notes-file --yes.${NC}"
+            exit 0
         fi
+    fi
 
-        # Commit the updated release notes and VERSION file
+    rm -f "${RELEASE_NOTES_PATH}.bak"
+
+    if [ "$commit_changes" = true ]; then
         echo -e "\n${CYAN}Committing the updated release notes and VERSION file...${NC}"
-        git add "$RELEASE_NOTES_PATH" "$ROOT_DIR/VERSION"
-        if ! git commit -m "docs: update release notes and version for $version"; then
-            echo -e "${YELLOW}⚠️ WARNING: Failed to commit the updated files.${NC}"
-            read -p "Do you want to continue anyway? (y/n): " confirmation
-            if [ "$confirmation" != "y" ]; then
+        git add "$RELEASE_NOTES_PATH" "$VERSION_FILE_PATH"
+        if ! git commit -m "chore(release): prepare $version"; then
+            echo -e "${YELLOW}WARNING: Failed to commit the updated files.${NC}"
+            if ! confirm_continue "Do you want to continue anyway?"; then
                 echo -e "${RED}Operation cancelled.${NC}"
                 exit 1
             fi
         else
-            echo -e "${GREEN}✅ Release notes and VERSION file committed successfully${NC}"
+            echo -e "${GREEN}Release notes and VERSION file committed successfully${NC}"
         fi
     fi
 }
@@ -308,48 +355,41 @@ function create_git_tag {
     echo -e "\n${CYAN}Creating Git tag: $version...${NC}"
 
     if [ "$DRY_RUN" = true ]; then
-        echo -e "${CYAN}🔍 [DRY RUN] Would create Git tag: $version${NC}"
-        echo -e "${CYAN}🔍 [DRY RUN] Would push Git tag to remote${NC}"
-        return
+        echo -e "${CYAN}[DRY RUN] Would create Git tag: $version${NC}"
+        echo -e "${CYAN}[DRY RUN] Would push Git tag to remote${NC}"
+        return 0
     fi
 
-    # Refuse if the tag already exists on remote — we do not force-push tags
     if git ls-remote --tags origin "refs/tags/$version" | grep -q "$version"; then
-        echo -e "${RED}❌ Tag $version already exists on remote. Refusing to retag.${NC}"
+        echo -e "${RED}Tag $version already exists on remote. Refusing to retag.${NC}"
         echo -e "${YELLOW}This script does not force-push tags. Delete the remote tag explicitly if you intend to replace it, then re-run.${NC}"
         exit 1
     fi
 
-    # Check if tag already exists locally
     if git tag -l "$version" | grep -q "$version"; then
-        echo -e "${YELLOW}⚠️ WARNING: Tag $version already exists locally.${NC}"
-        read -p "Do you want to replace the local tag and push it? (y/n): " confirmation
-        if [ "$confirmation" != "y" ]; then
+        echo -e "${YELLOW}WARNING: Tag $version already exists locally.${NC}"
+        if ! confirm_continue "Do you want to replace the local tag and push it?"; then
             echo -e "${RED}Operation cancelled.${NC}"
             exit 1
         fi
-
-        # Delete existing local tag only
         if ! git tag -d "$version"; then
-            echo -e "${RED}❌ Failed to delete existing local tag.${NC}"
+            echo -e "${RED}Failed to delete existing local tag.${NC}"
             exit 1
         fi
     fi
 
-    # Create the tag
     if ! git tag -a "$version" -m "Release $version"; then
-        echo -e "${RED}❌ Failed to create Git tag.${NC}"
+        echo -e "${RED}Failed to create Git tag.${NC}"
         exit 1
     fi
-    echo -e "${GREEN}✅ Git tag created successfully${NC}"
+    echo -e "${GREEN}Git tag created successfully${NC}"
 
-    # Push the tag (non-force)
     echo -e "\n${CYAN}Pushing Git tag to remote...${NC}"
     if ! git push origin "$version"; then
-        echo -e "${RED}❌ Failed to push Git tag to remote.${NC}"
+        echo -e "${RED}Failed to push Git tag to remote.${NC}"
         exit 1
     fi
-    echo -e "${GREEN}✅ Git tag pushed successfully${NC}"
+    echo -e "${GREEN}Git tag pushed successfully${NC}"
 }
 
 function build_docker_images {
@@ -357,65 +397,193 @@ function build_docker_images {
 
     echo -e "\n${CYAN}Checking Docker availability...${NC}"
 
-    # Check if Docker is installed
     if ! command -v docker &>/dev/null; then
-        echo -e "${RED}❌ Docker is not installed or not in PATH. Cannot build Docker images.${NC}"
-        read -p "Do you want to continue without building Docker images? (y/n): " confirmation
-        if [ "$confirmation" != "y" ]; then
+        echo -e "${RED}Docker is not installed or not in PATH. Cannot build Docker images.${NC}"
+        if ! confirm_continue "Do you want to continue without building Docker images?" 1; then
             echo -e "${RED}Operation cancelled.${NC}"
             exit 1
         fi
-        return
+        return 0
     fi
 
-    # Check if Docker is running
     if ! docker info &>/dev/null; then
-        echo -e "${RED}❌ Docker engine is not running. Cannot build Docker images.${NC}"
-        read -p "Do you want to continue without building Docker images? (y/n): " confirmation
-        if [ "$confirmation" != "y" ]; then
+        echo -e "${RED}Docker engine is not running. Cannot build Docker images.${NC}"
+        if ! confirm_continue "Do you want to continue without building Docker images?" 1; then
             echo -e "${RED}Operation cancelled.${NC}"
             exit 1
         fi
-        return
+        return 0
     fi
 
     echo -e "\n${CYAN}Building and pushing Docker images...${NC}"
 
     if [ "$DRY_RUN" = true ]; then
-        echo -e "${CYAN}🔍 [DRY RUN] Would build and push Docker images with tag: $version${NC}"
-        echo -e "${CYAN}🔍 [DRY RUN] Would execute: $DOCKER_BUILD_SCRIPT $version${NC}"
-        return
+        echo -e "${CYAN}[DRY RUN] Would build and push Docker images with tag: $version${NC}"
+        echo -e "${CYAN}[DRY RUN] Would execute: $DOCKER_BUILD_SCRIPT $version${NC}"
+        return 0
     fi
 
-    # Check if build script exists
     if [ ! -f "$DOCKER_BUILD_SCRIPT" ]; then
-        echo -e "${RED}❌ Docker build script not found at: $DOCKER_BUILD_SCRIPT${NC}"
-        read -p "Do you want to continue without building Docker images? (y/n): " confirmation
-        if [ "$confirmation" != "y" ]; then
+        echo -e "${RED}Docker build script not found at: $DOCKER_BUILD_SCRIPT${NC}"
+        if ! confirm_continue "Do you want to continue without building Docker images?" 1; then
             echo -e "${RED}Operation cancelled.${NC}"
             exit 1
         fi
-        return
+        return 0
     fi
 
-    # Make sure the script is executable
     chmod +x "$DOCKER_BUILD_SCRIPT"
-
-    # Run the build script
     echo -e "${CYAN}Running Docker build script with tag: $version${NC}"
     if ! "$DOCKER_BUILD_SCRIPT" "$version"; then
-        echo -e "${RED}❌ Docker build script failed.${NC}"
-        read -p "Do you want to continue anyway? (y/n): " confirmation
-        if [ "$confirmation" != "y" ]; then
+        echo -e "${RED}Docker build script failed.${NC}"
+        if ! confirm_continue "Do you want to continue anyway?"; then
             echo -e "${RED}Operation cancelled.${NC}"
             exit 1
         fi
     else
-        echo -e "${GREEN}✅ Docker images built and pushed successfully${NC}"
+        echo -e "${GREEN}Docker images built and pushed successfully${NC}"
     fi
 }
 
-# Process command line arguments
+function invoke_release_pr_mode {
+    local version="$1"
+    local changelog="$2"
+    local release_branch="release/$version"
+
+    echo -e "\n${CYAN}Release PR mode (default). Branch SSOT: $release_branch${NC}"
+
+    if [ "$BUILD_DOCKER" = true ]; then
+        echo -e "${YELLOW}WARNING: --build-docker is ignored in Release PR mode (images publish after tag on merge).${NC}"
+    fi
+
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${CYAN}[DRY RUN] Would create branch: $release_branch${NC}"
+        update_version_and_notes "$version" "$changelog" true
+        echo -e "${CYAN}[DRY RUN] Would push $release_branch and run: gh pr create --base main --head $release_branch${NC}"
+        echo -e "${CYAN}[DRY RUN] Would print the PR URL${NC}"
+        return 0
+    fi
+
+    if git ls-remote --tags origin "refs/tags/$version" | grep -q "$version"; then
+        echo -e "${RED}Tag $version already exists on remote. Refusing to open a Release PR for it.${NC}"
+        echo -e "${YELLOW}This script does not force-push tags.${NC}"
+        exit 1
+    fi
+
+    if git show-ref --verify --quiet "refs/heads/$release_branch"; then
+        echo -e "${RED}Local branch $release_branch already exists.${NC}"
+        exit 1
+    fi
+
+    if git ls-remote --heads origin "$release_branch" | grep -q "$release_branch"; then
+        echo -e "${RED}Remote branch $release_branch already exists.${NC}"
+        exit 1
+    fi
+
+    if ! test_gh_available; then
+        echo -e "${RED}GitHub CLI (gh) is required for Release PR mode. Install gh or use --direct-tag (discouraged).${NC}"
+        exit 1
+    fi
+
+    echo -e "${CYAN}Creating branch $release_branch...${NC}"
+    if ! git checkout -b "$release_branch"; then
+        echo -e "${RED}Failed to create branch $release_branch.${NC}"
+        exit 1
+    fi
+
+    update_version_and_notes "$version" "$changelog" true
+
+    echo -e "\n${CYAN}Pushing branch $release_branch...${NC}"
+    if ! git push -u origin "$release_branch"; then
+        echo -e "${RED}Failed to push branch $release_branch.${NC}"
+        exit 1
+    fi
+
+    local pr_body
+    pr_body=$(cat <<EOF
+## Summary
+- Prepare release **$version** (branch \`$release_branch\` is version SSOT).
+- Updates \`VERSION\` and \`docs/release-notes.md\`.
+
+## After merge
+- Tagging / GitHub Release should be created by CI (release-tag-on-merge).
+- Docker Hub images publish from the \`v*\` tag via Docker Publish.
+
+## Test plan
+- [ ] Release notes look correct
+- [ ] VERSION matches branch (without leading \`v\`)
+- [ ] CI green before merge
+EOF
+)
+
+    echo -e "\n${CYAN}Creating pull request...${NC}"
+    local pr_url
+    if ! pr_url=$(gh pr create --base main --head "$release_branch" --title "chore(release): $version" --body "$pr_body"); then
+        echo -e "${RED}Failed to create pull request.${NC}"
+        exit 1
+    fi
+
+    echo -e "\n${GREEN}Release PR created:${NC}"
+    echo -e "${WHITE}$pr_url${NC}"
+    echo -e "\n${YELLOW}Merge the PR to cut the release. Monitor: $REPO_ACTIONS_URL${NC}"
+}
+
+function invoke_direct_tag_mode {
+    local version="$1"
+    local changelog="$2"
+
+    echo -e "\n${YELLOW}WARNING: --direct-tag is an emergency path (tags from main, no Release PR).${NC}"
+
+    update_version_and_notes "$version" "$changelog" true
+
+    if [ "$DRY_RUN" != true ] && [ "$SKIP_NOTES" != true ]; then
+        echo -e "\n${CYAN}Pushing main (release notes / VERSION commit)...${NC}"
+        if ! git push origin main; then
+            echo -e "${RED}Failed to push main. Tag will not be created until main is pushed.${NC}"
+            exit 1
+        fi
+    elif [ "$DRY_RUN" = true ]; then
+        echo -e "${CYAN}[DRY RUN] Would push main after notes/VERSION commit${NC}"
+    fi
+
+    # When SkipNotes but VERSION was committed, still need push
+    if [ "$DRY_RUN" != true ] && [ "$SKIP_NOTES" = true ]; then
+        echo -e "\n${CYAN}Pushing main (VERSION commit)...${NC}"
+        if ! git push origin main; then
+            echo -e "${RED}Failed to push main.${NC}"
+            exit 1
+        fi
+    fi
+
+    create_git_tag "$version"
+
+    if [ "$BUILD_DOCKER" = true ]; then
+        build_docker_images "$version"
+    else
+        echo -e "\n${YELLOW}Skipping Docker build (use -b/--build-docker with --direct-tag to build images locally).${NC}"
+    fi
+
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "\n${GREEN}Dry run completed for direct-tag path: $version${NC}"
+    else
+        echo -e "\n${GREEN}Direct-tag release completed for: $version${NC}"
+        echo -e "${YELLOW}Next steps:${NC}"
+        echo -e "${WHITE}  1. Monitor GitHub Actions: $REPO_ACTIONS_URL${NC}"
+        echo -e "${WHITE}  2. Verify Docker images on Docker Hub${NC}"
+    fi
+}
+
+function clear_changelog_artifact {
+    if [ -f "$CHANGELOG_PATH" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${CYAN}[DRY RUN] Would clean up temporary files (changelog.txt left in place)${NC}"
+        else
+            rm -f "$CHANGELOG_PATH"
+            echo -e "${GREEN}Removed temporary changelog file${NC}"
+        fi
+    fi
+}
+
 while [[ $# -gt 0 ]]; do
     case $1 in
         -v|--version)
@@ -426,8 +594,20 @@ while [[ $# -gt 0 ]]; do
             PREVIOUS_TAG="$2"
             shift 2
             ;;
+        -n|--notes-file)
+            NOTES_FILE="$2"
+            shift 2
+            ;;
         -s|--skip-notes)
             SKIP_NOTES=true
+            shift
+            ;;
+        --direct-tag)
+            DIRECT_TAG=true
+            shift
+            ;;
+        -y|--yes)
+            YES=true
             shift
             ;;
         -b|--build-docker)
@@ -443,85 +623,60 @@ while [[ $# -gt 0 ]]; do
             exit 0
             ;;
         *)
-            echo -e "${RED}❌ Unknown option: $1${NC}"
+            echo -e "${RED}Unknown option: $1${NC}"
             show_help
             exit 1
             ;;
     esac
 done
 
-# Check required parameters
 if [ -z "$VERSION" ]; then
-    echo -e "${RED}❌ Version parameter is required. Use -v or --version to specify the version to release.${NC}"
+    echo -e "${RED}Version parameter is required. Use -v or --version.${NC}"
     show_help
     exit 1
 fi
 
-# Validate version format
 if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9\.]+)?$ ]]; then
-    echo -e "${RED}❌ Invalid version format. Version should be in the format 'vX.Y.Z' or 'vX.Y.Z-suffix'${NC}"
+    echo -e "${RED}Invalid version format. Use 'vX.Y.Z' or 'vX.Y.Z-suffix'.${NC}"
     echo -e "${CYAN}Examples: v1.0.0, v0.1.0-beta.1, v2.0.0-rc.3${NC}"
     exit 1
 fi
 
-# Check if Git is available
 test_git_available
 
-# Get previous tag if not specified
 if [ -z "$PREVIOUS_TAG" ]; then
     PREVIOUS_TAG=$(get_latest_git_tag) || PREVIOUS_TAG=""
 fi
 
-# Start the release process
+cd "$ROOT_DIR"
+
 if [ "$DRY_RUN" = true ]; then
-    echo -e "\n${CYAN}🔍 [DRY RUN] Starting release process simulation for version: $VERSION${NC}"
-    echo -e "${CYAN}🔍 No actual changes will be made to files or repositories.${NC}"
-else
-    echo -e "\n${GREEN}🚀 Starting release process for version: $VERSION${NC}"
-fi
-
-# Confirm and prepare main branch
-confirm_main_branch
-
-# Generate changelog
-CHANGELOG=$(generate_changelog "$PREVIOUS_TAG" "$VERSION")
-
-# Update release notes
-if [ "$SKIP_NOTES" = false ]; then
-    update_release_notes "$VERSION" "$CHANGELOG"
-else
-    echo -e "\n${YELLOW}⚠️ Skipping release notes update as requested.${NC}"
-fi
-
-# Create and push Git tag
-create_git_tag "$VERSION"
-
-# Build and push Docker images (only if --build-docker is specified)
-if [ "$BUILD_DOCKER" = true ]; then
-    build_docker_images "$VERSION"
-else
-    echo -e "\n${YELLOW}⚠️ Skipping Docker build (use -b/--build-docker flag to build images).${NC}"
-fi
-
-# Clean up temporary files
-if [ -f "$CHANGELOG_PATH" ]; then
-    if [ "$DRY_RUN" = true ]; then
-        echo -e "${CYAN}🔍 [DRY RUN] Would clean up temporary files${NC}"
+    echo -e "\n${CYAN}[DRY RUN] Starting release simulation for version: $VERSION${NC}"
+    if [ "$DIRECT_TAG" = true ]; then
+        echo -e "${CYAN}[DRY RUN] Mode: DirectTag (emergency)${NC}"
     else
-        rm -f "$CHANGELOG_PATH"
-        echo -e "${GREEN}✅ Removed temporary changelog file${NC}"
+        echo -e "${CYAN}[DRY RUN] Mode: Release PR (default)${NC}"
+    fi
+else
+    echo -e "\n${GREEN}Starting release process for version: $VERSION${NC}"
+    if [ "$DIRECT_TAG" = true ]; then
+        echo -e "${YELLOW}Mode: DirectTag (emergency)${NC}"
+    else
+        echo -e "${GREEN}Mode: Release PR (default)${NC}"
     fi
 fi
 
-if [ "$DRY_RUN" = true ]; then
-    echo -e "\n${GREEN}✅ Dry run completed successfully for version: $VERSION${NC}"
-    echo -e "${CYAN}No actual changes were made. Run without --dry-run to execute the release process.${NC}"
+assert_main_clean 1
+CHANGELOG=$(generate_changelog "$PREVIOUS_TAG")
+
+if [ "$DIRECT_TAG" = true ]; then
+    invoke_direct_tag_mode "$VERSION" "$CHANGELOG"
 else
-    echo -e "\n${GREEN}✅ Release process completed successfully for version: $VERSION${NC}"
-    echo -e "\n${YELLOW}📋 Next steps:${NC}"
-    echo -e "${WHITE}  1. Monitor GitHub Actions workflow at: https://github.com/mnaimfaizy/fastapi_rbac/actions${NC}"
-    echo -e "${WHITE}  2. Verify Docker images on Docker Hub${NC}"
-    echo -e "${WHITE}  3. Notify team members about the new release${NC}"
+    invoke_release_pr_mode "$VERSION" "$CHANGELOG"
 fi
 
-echo -e "\n${CYAN}Thank you for using the FastAPI RBAC Release Automation Script! 🎉${NC}"
+clear_changelog_artifact
+# Disable EXIT cleanup of changelog after successful non-dry path already cleared it
+trap - EXIT
+
+echo -e "\n${CYAN}Thank you for using the FastAPI RBAC Release Automation Script!${NC}"


### PR DESCRIPTION
## Summary
- Release scripts default to Release PR mode (emergency DirectTag kept)
- Tag + GitHub Release on merged release/v* PRs; docker-publish once per tag
- Release skill + release-notes sub-agent (canonical docs + harness wrappers)
- Docs: CHANGELOG.md scrub / release-notes SSOT (#83 — already satisfied on main via #90; verified on this branch)

## Test plan
- [x] Dry-run Create-Release.ps1 -Version v0.0.0-test -DryRun -Yes on clean main
- [x] Review release-tag-on-merge.yml logic
- [x] Confirm docker-publish no longer has release:published trigger
- [x] Spot-check #83: no doc requires root CHANGELOG.md

## Issues
Closes #83

Related: #84 (fix(release): align PowerShell release script with bash) was closed on main in #92.

Made with [Cursor](https://cursor.com)