### PR TITLE
fix(ci): dispatch Docker Publish after release tag

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -100,7 +100,7 @@ Optional dry-run first: add `-DryRun` / `--dry-run` (still writes `changelog.txt
 ### 7. Finish
 
 - Print the **PR URL** from the script output (primary deliverable).
-- One-line reminder: after merge, `release-tag-on-merge` creates the tag + GitHub Release; `docker-publish` builds images once from the `v*` tag.
+- One-line reminder: after merge, `release-tag-on-merge` creates the tag + GitHub Release and dispatches `docker-publish` (manual `v*` tag push or Actions → Run workflow still work).
 - Do not merge the PR unless the user asks.
 - Do not push tags yourself.
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,11 @@
 name: Docker Publish
 
-# Publish on v* tag push (or manual dispatch). Do not also trigger on
-# release: published — Release Tag on Merge creates a GitHub Release after the
-# tag, which would double-build images if both triggers were enabled.
+# Publish paths (keep both):
+# 1) push of a v* tag (human / non-GITHUB_TOKEN push)
+# 2) workflow_dispatch with tag input (manual Run workflow, or Release Tag on
+#    Merge after it creates the tag — GITHUB_TOKEN tag pushes do not start this
+#    workflow, so that job dispatches instead)
+# Do not also trigger on release: published (would double-build with path 2).
 
 on:
   push:
@@ -27,6 +30,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Fetches all history and tags, useful if script falls back to git describe
+          # Manual/auto dispatch must build the tagged commit, not whatever branch
+          # was selected in the Actions UI (often main after later commits).
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/release-tag-on-merge.yml
+++ b/.github/workflows/release-tag-on-merge.yml
@@ -2,8 +2,11 @@ name: Release Tag on Merge
 
 # When a Release PR (head branch release/v*) is merged into main, create the
 # annotated SemVer tag and a GitHub Release. Branch name is the version SSOT.
-# Docker images publish via docker-publish.yml on the v* tag push (not on
-# release: published — that trigger was removed to avoid double builds).
+#
+# Docker Publish: tags pushed with GITHUB_TOKEN do not start other workflows, so
+# this job dispatches docker-publish.yml via workflow_dispatch after the tag
+# exists. Manual paths remain: push a v* tag yourself, or Run workflow on
+# Docker Publish. Do not also trigger on release: published (avoids double builds).
 
 on:
   pull_request:
@@ -12,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   tag-and-release:
@@ -149,4 +153,19 @@ jobs:
           echo "- Tag / release: \`${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Branch SSOT: \`${{ steps.version.outputs.branch }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Pre-release: \`${PRERELEASE}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Docker Publish should run once from the tag push." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Trigger Docker Publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # workflow_dispatch is allowed to chain from GITHUB_TOKEN; tag push is not.
+          gh workflow run docker-publish.yml \
+            --repo "${{ github.repository }}" \
+            -f tag="${VERSION}"
+
+          echo "Dispatched Docker Publish for ${VERSION}"
+          echo "- Docker Publish: dispatched (\`${VERSION}\`)." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/deployment/QUICK_RELEASE_GUIDE.md
+++ b/docs/deployment/QUICK_RELEASE_GUIDE.md
@@ -108,11 +108,16 @@ git branch -d hotfix/v1.2.4
 
 ### Scenario 6: Manual Workflow Trigger
 
-**When:** Need to rebuild/republish existing version
+**When:** Need to rebuild/republish an existing version, or publish when the automatic dispatch after Release Tag on Merge did not run
+
+Docker Publish supports two triggers (both valid):
+
+- **Automatic after Release PR merge:** `release-tag-on-merge` creates the `v*` tag/Release, then dispatches Docker Publish (a tag push from `GITHUB_TOKEN` alone does not start other workflows).
+- **Manual:** push a `v*` tag yourself, or use **Actions → Docker Publish → Run workflow** with the version tag.
 
 1. Go to GitHub Actions → Docker Publish workflow
 2. Click "Run workflow"
-3. Select branch (usually main)
+3. Select branch (usually main; the workflow checks out the **tag** you enter next)
 4. Enter version tag (e.g., `v1.2.3`)
 5. Click "Run workflow"
 

--- a/docs/deployment/RELEASE_PROCESS.md
+++ b/docs/deployment/RELEASE_PROCESS.md
@@ -71,8 +71,8 @@ The GitHub Actions workflow is configured to trigger on any tag starting with `v
 
 ## What Happens Next (Automation)
 
-1.  **GitHub Actions Workflow Triggered:** Pushing a tag matching the `v*` pattern automatically triggers the "Docker Publish" workflow defined in `.github/workflows/docker-publish.yml`.
-2.  **Image Build & Tag:** The workflow checks out the code corresponding to the pushed Git tag. It then builds the Docker images for the backend, frontend, and worker services. The Docker images will be tagged with the same version as the Git tag (e.g., `yourusername/fastapi-rbac-backend:v1.0.0`).
+1.  **GitHub Actions Workflow Triggered:** Docker Publish runs when a `v*` tag is pushed (human/local push), or via **workflow_dispatch** (Actions → Run workflow, or automatic dispatch from **Release Tag on Merge** after a Release PR). Tags created with `GITHUB_TOKEN` inside Actions do not start other workflows on push alone, which is why the Release Tag job dispatches Docker Publish explicitly.
+2.  **Image Build & Tag:** The workflow checks out the tagged commit (including when started via workflow_dispatch). It then builds the Docker images for the backend, frontend, and worker services. The Docker images will be tagged with the same version as the Git tag (e.g., `yourusername/fastapi-rbac-backend:v1.0.0`).
 3.  **Push to Docker Hub:** After a successful build, the tagged Docker images are pushed to your configured Docker Hub repository. The workflow also updates Hub repository descriptions from `backend/README.dockerhub.md`, `react-frontend/README.dockerhub.md`, and `backend/README.worker.dockerhub.md` (not from `docs/release-notes.md`).
 
 ## Verifying the Release


### PR DESCRIPTION
## Summary
- After Release Tag on Merge creates the `v*` tag/Release, dispatch `docker-publish` via `workflow_dispatch` (GITHUB_TOKEN tag pushes do not trigger other workflows).
- Keep both publish paths: automatic dispatch after Release PR merge, and manual (`v*` tag push or Actions → Run workflow).
- On `workflow_dispatch`, check out the **tag** input so rebuilds do not build an unrelated branch tip.

## Test plan
- [x] Merge this PR to `main`
- [x] Manually run **Docker Publish** for `v0.1.0-beta` (this release) and confirm images publish
- [x] On the next Release PR merge, confirm Release Tag on Merge summary shows Docker Publish dispatched and a Docker Publish run starts with that tag
- [x] Confirm a human `git push origin vX.Y.Z` still starts Docker Publish from the tag push event (no double-build from Release Tag unless that path also ran)