### PR TITLE
refactor(deps): consolidate HTTP rate limits onto slowapi (#64)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,31 @@
+# FastAPI RBAC
+
+Role-based access control API and admin UI: users, roles, permissions, and auth session controls.
+
+## Language
+
+**HTTP rate limit**:
+A coarse request quota enforced by the shared slowapi limiter on selected HTTP routes (keyed by client IP today).
+_Avoid_: Rate limiting (when referring only to this mechanism), fastapi-limiter, DoS middleware
+
+**Abuse counter**:
+A hand-rolled Redis incr/expire guard used for registration and resend-verification abuse (IP and/or email keys), independent of the HTTP rate limit library.
+_Avoid_: Rate limiting (when referring only to this mechanism), slowapi limit
+
+**User**:
+An account principal that authenticates and is assigned roles.
+_Avoid_: Account (when meaning the auth principal), client
+
+**Role**:
+A named set of permissions assignable to users.
+_Avoid_: Group (when meaning a role)
+
+**Permission**:
+An authorization atom granted via roles (and related grouping constructs).
+_Avoid_: Entitlement, capability
+
+**Role group**:
+A grouping construct for roles in this product's RBAC model.
+
+**Permission group**:
+A grouping construct for permissions in this product's RBAC model.

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -10,8 +10,6 @@ from fastapi.security import OAuth2PasswordRequestForm
 from fastapi_csrf_protect import CsrfProtect
 from pydantic import EmailStr
 from redis.asyncio import Redis as AsyncRedis
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app import crud
@@ -19,6 +17,7 @@ from app.api import deps
 from app.api.deps import get_redis_client, get_strict_sanitizer
 from app.core import security  # security module contains token functions
 from app.core.config import ModeEnum, settings
+from app.core.rate_limit import limiter
 from app.core.security import (  # For password complexity / JWT audit mapping
     PasswordValidator,
     decode_token,
@@ -48,20 +47,6 @@ from app.utils.token import add_token_to_redis, get_valid_tokens, token_is_allow
 from app.utils.user_utils import serialize_user
 
 logger = logging.getLogger("fastapi_rbac")
-
-# Create limiter instance for this module
-limiter = Limiter(key_func=get_remote_address)
-
-
-# Disable or relax rate limiting in test mode
-def _relax_limiter_for_testing() -> None:
-    from app.core.config import ModeEnum, settings
-
-    if getattr(settings, "MODE", None) == ModeEnum.testing or settings.MODE == "testing":
-        limiter.enabled = False  # Completely disable rate limiting in test mode
-
-
-_relax_limiter_for_testing()
 
 router = APIRouter()
 

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -1,0 +1,38 @@
+"""Shared slowapi HTTP rate limiter for the FastAPI app.
+
+HTTP rate limits use this single Limiter instance (app.state + route decorators).
+Abuse counters (hand-rolled Redis incr/expire in auth) are separate.
+"""
+
+from __future__ import annotations
+
+import os
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from app.core.config import ModeEnum, settings
+from app.core.service_config import service_settings
+
+
+def _is_testing() -> bool:
+    return (
+        os.environ.get("MODE") == "testing" or settings.MODE == ModeEnum.testing or settings.MODE == "testing"
+    )
+
+
+def _storage_uri() -> str:
+    """Memory in testing; Redis (service_settings.redis_url) otherwise."""
+    if _is_testing():
+        return "memory://"
+    return service_settings.redis_url
+
+
+def create_limiter() -> Limiter:
+    limiter = Limiter(key_func=get_remote_address, storage_uri=_storage_uri())
+    if _is_testing():
+        limiter.enabled = False
+    return limiter
+
+
+limiter = create_limiter()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ import logging
 import os
 from contextlib import asynccontextmanager
 from logging.config import fileConfig
-from typing import AsyncGenerator, Callable, Dict, List, Optional, Tuple
+from typing import AsyncGenerator, Callable, Dict, List, Tuple
 
 from fastapi import FastAPI, Request, Response, status
 from fastapi.exceptions import RequestValidationError
@@ -12,12 +12,9 @@ from fastapi_async_sqlalchemy import SQLAlchemyMiddleware
 from fastapi_cache import FastAPICache
 from fastapi_cache.backends.redis import RedisBackend
 from fastapi_csrf_protect import CsrfProtect
-from fastapi_limiter import FastAPILimiter
 from fastapi_pagination import add_pagination
-from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
-from slowapi.util import get_remote_address
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.pool import NullPool
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -30,7 +27,7 @@ from app.api.deps import get_redis_client
 from app.api.v1.api import api_router as api_router_v1
 from app.celery_app import celery_app
 from app.core.config import ModeEnum, settings
-from app.core.security import decode_token
+from app.core.rate_limit import limiter
 from app.core.service_config import service_settings
 from app.schemas.response_schema import ErrorDetail, create_error_response
 from app.utils.exceptions.user_exceptions import UserSelfDeleteException
@@ -131,34 +128,6 @@ CELERY_AVAILABLE = service_settings.use_celery
 celery = celery_app
 
 
-async def user_id_identifier(request: Request) -> Optional[str]:
-    if request.scope["type"] == "http":
-        # Retrieve the Authorization header from the request
-        auth_header = request.headers.get("Authorization")
-
-        if auth_header is not None:
-            # Check that the header is in the correct format
-            header_parts = auth_header.split()
-            if len(header_parts) == 2 and header_parts[0].lower() == "bearer":
-                token = header_parts[1]
-                payload = decode_token(token)
-
-                user_id = payload["sub"]
-
-                return str(user_id)
-
-    if request.scope["type"] == "websocket":
-        return str(request.scope["path"])
-
-    forwarded = request.headers.get("X-Forwarded-For")
-    if forwarded:
-        return str(forwarded.split(",")[0])
-
-    client = request.client
-    ip = getattr(client, "host", "0.0.0.0")
-    return str(ip) + ":" + str(request.scope["path"])
-
-
 @asynccontextmanager
 async def lifespan(fastapi_instance: FastAPI) -> AsyncGenerator[None, None]:
     # Startup
@@ -171,12 +140,10 @@ async def lifespan(fastapi_instance: FastAPI) -> AsyncGenerator[None, None]:
 
     if redis_client:
         FastAPICache.init(RedisBackend(redis_client), prefix="fastapi-cache")
-        await FastAPILimiter.init(redis_client, identifier=user_id_identifier)
 
     yield
     # shutdown
     await FastAPICache.clear()
-    await FastAPILimiter.close()
     if redis_client:
         # Connection is returned to pool, pool cleanup happens below
         pass
@@ -200,8 +167,7 @@ fastapi_app = FastAPI(
     lifespan=lifespan,
 )
 
-# Create limiter instance for rate limiting
-limiter = Limiter(key_func=get_remote_address)
+# Shared HTTP rate limiter (slowapi) — see app.core.rate_limit
 fastapi_app.state.limiter = limiter
 fastapi_app.add_middleware(SlowAPIMiddleware)
 
@@ -343,21 +309,6 @@ async def custom_swagger_ui_html() -> HTMLResponse:
 
 
 # Exception handlers for consistent error responses
-@fastapi_app.exception_handler(RateLimitExceeded)
-async def rate_limit_exception_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
-    """
-    Handle rate limit exceeded errors with standardized JSON response
-    """
-    return JSONResponse(
-        status_code=429,
-        content={
-            "success": False,
-            "message": f"Rate limit exceeded: {exc.detail}",
-            "code": "RATE_LIMIT_EXCEEDED",
-        },
-    )
-
-
 @fastapi_app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
     """

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -6,6 +6,9 @@ This file adds the current directory to the Python path.
 import os
 import sys
 
+# Must run before pytest_plugins import app.main (via fixtures_app).
+os.environ["MODE"] = "testing"
+
 # Add the project root directory to Python's path
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 

--- a/backend/docs/REDIS_SSL_SETUP.md
+++ b/backend/docs/REDIS_SSL_SETUP.md
@@ -18,7 +18,8 @@ This document provides comprehensive guidance on configuring and managing Redis 
 The FastAPI RBAC application uses Redis for:
 - Session management and token storage
 - Caching via FastAPI-Cache
-- Rate limiting via FastAPI-Limiter
+- HTTP rate limit storage via slowapi (`storage_uri`, non-testing modes)
+- Abuse counters for registration / resend-verification (hand-rolled keys in auth)
 - Celery message broker and result backend
 
 In production, all Redis connections **must** use SSL/TLS to ensure:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -40,7 +40,6 @@ fastapi-async-sqlalchemy==0.6.1
 fastapi-cache2==0.2.2
 fastapi-cli==0.0.7
 fastapi-csrf-protect==1.0.7
-fastapi-limiter==0.1.6
 fastapi-pagination==0.13.1
 filelock==3.18.0
 flake8==7.3.0

--- a/backend/test/integration/test_api_auth_comprehensive.py
+++ b/backend/test/integration/test_api_auth_comprehensive.py
@@ -328,26 +328,29 @@ class TestAuthenticationSecurity:
 
     @pytest.mark.asyncio
     async def test_rate_limiting_on_login(self, client: AsyncClient) -> None:
-        """Test rate limiting on login attempts."""
+        """Burst auth login stays within expected client-error statuses.
+
+        HTTP rate limits are disabled in testing by default. Asserted 429 behavior
+        for slowapi lives in ``test/unit/test_rate_limit.py``.
+        """
 
         email = random_email()
-        login_data = {"username": email, "password": "any_password"}
+        login_data = {"email": email, "password": "any_password"}
 
         # Get CSRF token for requests
         csrf_token, csrf_headers = await get_csrf_token(client)
-        csrf_headers["Content-Type"] = "application/x-www-form-urlencoded"
+        csrf_headers["Content-Type"] = "application/json"
 
-        # Make rapid login attempts to trigger rate limiting
+        # Make rapid login attempts (limiter off in testing — expect auth/validation errors)
         responses = []
-        for i in range(10):  # Exceed typical rate limit
+        for i in range(10):
             response = await client.post(
                 f"{settings.API_V1_STR}/auth/login",
-                data=login_data,
+                json=login_data,
                 headers=csrf_headers,
             )
             responses.append(response.status_code)
 
-        # Should see 429 (Too Many Requests) after several attempts OR consistent error handling
         valid_responses = [400, 401, 422, 429]
         assert all(status in valid_responses for status in responses)
 

--- a/backend/test/unit/test_rate_limit.py
+++ b/backend/test/unit/test_rate_limit.py
@@ -1,0 +1,79 @@
+"""HTTP rate limit wiring seams (slowapi consolidation — issue #64)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from test.utils import random_email
+
+import pytest
+from httpx import AsyncClient
+
+from app.core.config import settings
+
+
+def test_main_does_not_import_fastapi_limiter() -> None:
+    """App wiring must not depend on fastapi-limiter (init-only scaffold removed)."""
+    main_path = Path(__file__).resolve().parents[2] / "app" / "main.py"
+    tree = ast.parse(main_path.read_text(encoding="utf-8"))
+    imported_modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported_modules.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.add(node.module.split(".")[0])
+    assert "fastapi_limiter" not in imported_modules
+
+
+def test_shared_limiter_disabled_in_testing_by_default() -> None:
+    from app.core.rate_limit import create_limiter
+
+    lim = create_limiter()
+    assert lim.enabled is False
+
+
+def _reset_limiter_storage(limiter: object) -> None:
+    storage = getattr(limiter, "_storage", None)
+    if storage is None:
+        return
+    if hasattr(storage, "reset"):
+        storage.reset()
+    elif hasattr(storage, "clear"):
+        storage.clear()
+
+
+@pytest.mark.asyncio
+async def test_access_token_http_rate_limit_returns_429_when_enabled(
+    client: AsyncClient,
+) -> None:
+    """Burst past access-token's 5/minute HTTP rate limit → 429 with standardized JSON."""
+    from app.core.rate_limit import limiter
+
+    previous = limiter.enabled
+    limiter.enabled = True
+    _reset_limiter_storage(limiter)
+    try:
+        email = random_email()
+        form = {"username": email, "password": "any_password"}
+
+        statuses: list[int] = []
+        last_response = None
+        for _ in range(6):
+            last_response = await client.post(
+                f"{settings.API_V1_STR}/auth/access-token",
+                data=form,
+            )
+            statuses.append(last_response.status_code)
+
+        assert 429 in statuses, f"expected HTTP rate limit 429, got {statuses}"
+        assert last_response is not None
+        assert last_response.status_code == 429
+        body = last_response.json()
+        assert body.get("status") == "error"
+        assert body.get("message") == "Rate limit exceeded"
+        error_codes = [err.get("code") for err in body.get("errors", [])]
+        assert "rate_limit" in error_codes
+    finally:
+        limiter.enabled = previous
+        _reset_limiter_storage(limiter)

--- a/docs/adr/0002-slowapi-sole-http-rate-limit.md
+++ b/docs/adr/0002-slowapi-sole-http-rate-limit.md
@@ -1,0 +1,7 @@
+# slowapi as the sole HTTP rate limit library; keep Redis abuse counters
+
+Auth carried two overlapping stacks: scaffold `fastapi-limiter` (Redis `FastAPILimiter` init in lifespan, never applied to routes) and `slowapi` (live `@limiter.limit` on auth endpoints, default in-memory storage). We consolidated on **slowapi only**, removed `fastapi-limiter`, unified on one shared `Limiter` in `app/core/rate_limit.py`, and use Redis `storage_uri` from `service_settings.redis_url` outside testing so HTTP rate limits are shared across workers. Hand-rolled Redis **abuse counters** for registration/resend-verification stay as a separate control. Dual libraries and a phantom Redis limiter path were higher risk than keeping the already-enforcing slowapi stack; folding abuse counters into slowapi remains a follow-up, not part of this change.
+
+## Smoke (manual)
+
+With the API up (non-testing mode), burst six `POST /api/v1/auth/access-token` form requests from the same client within one minute. Expect **HTTP 429**, JSON `status: "error"`, `message: "Rate limit exceeded"`, error code `rate_limit`, and slowapi rate-limit response headers when injected (`X-RateLimit-*` / `Retry-After` as applicable).

--- a/docs/development/DEPENDENCY_UPGRADES.md
+++ b/docs/development/DEPENDENCY_UPGRADES.md
@@ -41,7 +41,7 @@ A follow-up may align Poetry with `requirements.txt`; until then, always pin and
 Upgrade carefully (changelog review; prefer split PRs if needed):
 
 - SQLModel / SQLAlchemy API (`AsyncSession` + `.exec()`, not `.execute()`)
-- FastAPI middleware affecting CSRF / rate limiting (`fastapi-csrf-protect`, `fastapi-limiter` / `slowapi`)
+- FastAPI middleware affecting CSRF / HTTP rate limits (`fastapi-csrf-protect`, `slowapi`)
 - Redis client + token utilities
 - Celery / kombu / broker compatibility
 - PyJWT / passlib / bcrypt
@@ -90,7 +90,7 @@ About **76** advisory hits across pinned packages (many packages have multiple a
 | `ecdsa` | **Removed** with `python-jose` (HS256-only app; no direct imports) — see #63 | Lane 2 follow-up |
 | `python-jose` | **Removed** — consolidated JWT onto PyJWT only (#63 / [ADR 0001](../adr/0001-pyjwt-sole-jwt-library.md)) | Lane 2 follow-up |
 | `redis` | Patched in Lane 2 → `5.3.1` (no OSV hits on 5.2.1; **major 6+/8 deferred** — hard-stop) | Lane 2 / later |
-| `fastapi-limiter` | Kept `0.1.6` — `0.2.0` is a breaking rewrite (drops Redis `FastAPILimiter`) | Lane 2 follow-up |
+| `fastapi-limiter` | **Removed** — unused scaffold init only; HTTP rate limits consolidated onto `slowapi` (#64 / [ADR 0002](../adr/0002-slowapi-sole-http-rate-limit.md)) | Lane 2 follow-up |
 | `bcrypt` / `passlib` | No OSV hits; left on `4.3.0` / `1.7.4` | Lane 2 |
 | `gunicorn` | **Fixed in Lane 4** → `26.0.0` (request-smuggling advisories needed ≥22) | Lane 4 |
 | `tornado` | **Fixed in Lane 4** → `6.5.7` (flower still requires `<7`) | Lane 4 |
@@ -111,6 +111,12 @@ About **76** advisory hits across pinned packages (many packages have multiple a
 - **Runtime:** `app/core/security.py` encode/decode; session invalidation remains Redis **allowlist** (`app/utils/token.py`), not jti blacklist.
 - **Removed:** unused `app/utils/token_manager.py` (never imported by live auth).
 - **Deferred (security debt, not part of #63 behavior change):** see umbrella [#67](https://github.com/mnaimfaizy/fastapi_rbac/issues/67) — enforce/retire `password_version`; `VALIDATE_TOKEN_IP` honesty/implement; concurrent session limit; orphan `TOKEN_BLACKLIST_*` settings.
+
+### Lane 2 hard-stop follow-up — HTTP rate limit consolidation (#64, 2026-07-24)
+
+- **Decision:** `slowapi` is the only HTTP rate limit library; unused `fastapi-limiter` removed. See [ADR 0002](../adr/0002-slowapi-sole-http-rate-limit.md) and [research note](../internal/research/rate-limiting-library-consolidation.md).
+- **Runtime:** shared `Limiter` in `app/core/rate_limit.py` (Redis `storage_uri` outside testing; memory + disabled in testing); auth routes keep existing `@limiter.limit` thresholds.
+- **Kept separate:** Redis **abuse counters** for registration / resend-verification in `auth.py` (not folded into slowapi in this change).
 
 ### Lane 3 notes (2026-07-17)
 

--- a/docs/internal/research/rate-limiting-library-consolidation.md
+++ b/docs/internal/research/rate-limiting-library-consolidation.md
@@ -1,0 +1,196 @@
+# Rate-Limiting Library Consolidation Research
+
+**Date:** 2026-07-24
+**Scope:** Issue [#64](https://github.com/mnaimfaizy/fastapi_rbac/issues/64) — consolidate `fastapi-limiter` vs `slowapi` in `mnaimfaizy/fastapi_rbac`
+**Sources:** Primary only — upstream READMEs, PyPI metadata, GitHub compare/API, `limits` / PyrateLimiter docs, and this repo’s git history + internal docs.
+**Status (post-#64):** Decision implemented — **slowapi only**; `fastapi-limiter` removed. See [ADR 0002](../../adr/0002-slowapi-sole-http-rate-limit.md). Sections below describe the pre-change investigation unless marked otherwise.
+
+---
+
+## Executive summary
+
+**Before #64:** This repo carried **two rate-limiting libraries**. **`slowapi`** was the only one that **enforced limits on routes** (four auth endpoints via `@limiter.limit`). **`fastapi-limiter` 0.1.6** was **init-only**: `FastAPILimiter.init/close` ran in lifespan but **no route used `RateLimiter`**.
+
+Historical reason: `fastapi-limiter` shipped with the original project scaffold (Apr 2025); `slowapi` was added later (Jun 2025) as an explicit P0 security item without removing the scaffold wiring.
+
+**Recommendation for #64:** Keep **slowapi**, remove **fastapi-limiter**, and **configure slowapi with Redis `storage_uri`** so limits are shared across Gunicorn/Uvicorn workers. Optionally fold bespoke Redis counters in `auth.py` (registration / resend-verification) into slowapi limits in a follow-up.
+
+---
+
+## Feature comparison
+
+| Dimension | fastapi-limiter **0.1.6** (pinned) | fastapi-limiter **0.2.0** (latest) | slowapi **0.1.10** (repo pin) |
+|-----------|--------------------------------------|-------------------------------------|-------------------------------|
+| **Underlying engine** | Redis Lua script via `redis` ([0.1.6 README](https://github.com/long2ice/fastapi-limiter/blob/v0.1.6/README.md)) | [PyrateLimiter](https://github.com/vutran1710/PyrateLimiter) (`pyrate-limiter>=3.9.0`) ([0.2.0 `pyproject.toml`](https://github.com/long2ice/fastapi-limiter/blob/v0.2.0/pyproject.toml), [master README](https://github.com/long2ice/fastapi-limiter/blob/master/README.md)) | [limits](https://limits.readthedocs.io/en/stable/) ([slowapi README](https://github.com/laurentS/slowapi/blob/master/README.md)) |
+| **Storage backends** | **Redis required** ([0.1.6 README](https://github.com/long2ice/fastapi-limiter/blob/v0.1.6/README.md)) | In-memory default via PyrateLimiter; optional Redis/SQLite/Postgres/multiprocessing ([PyrateLimiter README](https://github.com/vutran1710/PyrateLimiter/blob/master/README.md)) | Memory (default/fallback), Redis, Memcached, MongoDB, Valkey, Redis Cluster/Sentinel/SSL ([limits storage](https://limits.readthedocs.io/en/stable/storage.html), [slowapi README](https://github.com/laurentS/slowapi/blob/master/README.md)) |
+| **API style** | `await FastAPILimiter.init(redis)` + `Depends(RateLimiter(times=…, seconds=…))` ([0.1.6 README](https://github.com/long2ice/fastapi-limiter/blob/v0.1.6/README.md)) | `Depends(RateLimiter(limiter=Limiter(Rate(…))))` — **no** `FastAPILimiter.init` ([master README](https://github.com/long2ice/fastapi-limiter/blob/master/README.md)) | `@limiter.limit("5/minute")` on routes; `Request` param required ([slowapi docs](https://slowapi.readthedocs.io/en/latest/)) |
+| **Middleware vs deps** | Dependency-first; optional `RateLimiterMiddleware` in 0.2 ([master README](https://github.com/long2ice/fastapi-limiter/blob/master/README.md)) | Same | Decorator + `SlowAPIMiddleware` / `SlowAPIASGIMiddleware` ([examples](https://github.com/laurentS/slowapi/blob/master/docs/examples.md), [middleware source](https://github.com/laurentS/slowapi/blob/master/slowapi/middleware.py)) |
+| **Multi-worker / distributed** | **Yes** when Redis init is used (0.1.x) | **Only if** PyrateLimiter bucket uses Redis/Postgres/etc.; default in-memory is **per-process** ([PyrateLimiter backends table](https://github.com/vutran1710/PyrateLimiter/blob/master/README.md)) | **Only with** `storage_uri` (e.g. `redis://…`); default in-memory is **per-process** ([slowapi examples](https://github.com/laurentS/slowapi/blob/master/docs/examples.md)) |
+| **Redis integration** | Native, mandatory in 0.1.x | Opt-in via PyrateLimiter `RedisBucket` | `Limiter(..., storage_uri="redis://host:port/n")` ([slowapi examples](https://github.com/laurentS/slowapi/blob/master/docs/examples.md)) |
+| **WebSocket support** | Yes (`WebSocketRateLimiter`) ([0.1.6 README](https://github.com/long2ice/fastapi-limiter/blob/v0.1.6/README.md)) | Yes ([master README](https://github.com/long2ice/fastapi-limiter/blob/master/README.md)) | **Not supported** ([slowapi docs](https://slowapi.readthedocs.io/en/latest/)) |
+| **Shared limits / global default** | Multiple `RateLimiter` deps per route | Same + `skip_limiter` / `skip` callable (0.2) | `default_limits`, `shared_limit`, `@limiter.exempt` ([slowapi examples](https://github.com/laurentS/slowapi/blob/master/docs/examples.md)) |
+| **Maintenance / activity** | Last release **0.2.0** 2026-02-06 ([PyPI](https://pypi.org/project/fastapi-limiter/)); GitHub pushed 2026-02-06 ([API](https://api.github.com/repos/long2ice/fastapi-limiter)) | Same | Last release **0.1.10** 2026-06-13 ([PyPI](https://pypi.org/project/slowapi/)); GitHub pushed **2026-07-23** ([API](https://api.github.com/repos/laurentS/slowapi)) |
+| **GitHub stars / issues** | **789** stars, **31** open issues ([API](https://api.github.com/repos/long2ice/fastapi-limiter)) | Same repo | **2,037** stars, **98** open issues ([API](https://api.github.com/repos/laurentS/slowapi)) |
+| **Engine stars** | N/A (embedded Redis script) | PyrateLimiter **512** stars ([API](https://api.github.com/repos/vutran1710/PyrateLimiter)) | `limits` — mature, used by Flask-Limiter ecosystem ([limits docs](https://limits.readthedocs.io/en/stable/)) |
+
+---
+
+## fastapi-limiter 0.2.0 breaking changes (vs 0.1.6)
+
+Primary evidence: [GitHub compare `v0.1.6...v0.2.0`](https://github.com/long2ice/fastapi-limiter/compare/v0.1.6...v0.2.0), [0.1.6 vs master README](https://github.com/long2ice/fastapi-limiter/compare/v0.1.6...master), [PyPI 0.1.6 vs 0.2.0 metadata](https://pypi.org/pypi/fastapi-limiter/json).
+
+| Breaking change | Detail | Source |
+|-----------------|--------|--------|
+| **Removes `FastAPILimiter` class** | `fastapi_limiter/__init__.py` drops ~89 lines including `FastAPILimiter.init/close` | [compare](https://github.com/long2ice/fastapi-limiter/compare/v0.1.6...v0.2.0) — commit `ae102cf` |
+| **Redis no longer built-in** | 0.1.6 depends on `redis`; 0.2.0 depends on `pyrate-limiter>=3.9.0` only | [0.1.6 `pyproject.toml`](https://github.com/long2ice/fastapi-limiter/blob/v0.1.6/pyproject.toml), [0.2.0 `pyproject.toml`](https://github.com/long2ice/fastapi-limiter/blob/v0.2.0/pyproject.toml) |
+| **`RateLimiter` API rewrite** | Was `RateLimiter(times=2, seconds=5)`; now `RateLimiter(limiter=Limiter(Rate(2, Duration.SECOND * 5)))` | [0.1.6 README](https://github.com/long2ice/fastapi-limiter/blob/v0.1.6/README.md), [master README](https://github.com/long2ice/fastapi-limiter/blob/master/README.md) |
+| **Startup pattern change** | 0.1.x: `await FastAPILimiter.init(redis_connection)` on startup; 0.2.x: no global init — configure `Limiter`/`RateLimiter` per route or use middleware | [0.1.6 README](https://github.com/long2ice/fastapi-limiter/blob/v0.1.6/README.md), [master README](https://github.com/long2ice/fastapi-limiter/blob/master/README.md) |
+| **Lifespan / `@on_event` migration** | Compare includes `use lifespan` commit replacing deprecated `on_event` | [compare commits](https://github.com/long2ice/fastapi-limiter/compare/v0.1.6...v0.2.0) |
+| **CHANGELOG removed at 0.2.0 tag** | `CHANGELOG.md` deleted in 0.2.0 tree; 0.1.6 changelog documents earlier 0.1.x breaks only | [compare](https://github.com/long2ice/fastapi-limiter/compare/v0.1.6...v0.2.0), [0.1.6 CHANGELOG](https://github.com/long2ice/fastapi-limiter/blob/v0.1.6/CHANGELOG.md) |
+
+This repo explicitly deferred 0.2.0 for that rewrite: [`docs/development/DEPENDENCY_UPGRADES.md`](../../development/DEPENDENCY_UPGRADES.md) — *“Kept `0.1.6` — `0.2.0` is a breaking rewrite (drops Redis `FastAPILimiter`)”*.
+
+---
+
+## What this repo uses today
+
+### Dependencies (`backend/requirements.txt`)
+
+| Package | Version | Role |
+|---------|---------|------|
+| `fastapi-limiter` | `0.1.6` | Declared; **no route enforcement** |
+| `slowapi` | `0.1.10` | **Active route limits** |
+
+### fastapi-limiter — **init only**
+
+| Location | Usage |
+|----------|--------|
+| `backend/app/main.py` | `from fastapi_limiter import FastAPILimiter`; `await FastAPILimiter.init(redis_client, identifier=user_id_identifier)` and `await FastAPILimiter.close()` in lifespan |
+| `backend/app/main.py` | Custom `user_id_identifier()` (Bearer `sub`, WebSocket path, `X-Forwarded-For`, IP+path) — **only passed to `FastAPILimiter.init`, unused elsewhere** |
+
+**Grep result:** No `RateLimiter`, `Depends(RateLimiter`, or `@limiter` from fastapi-limiter anywhere under `backend/`.
+
+### slowapi — **enforces limits**
+
+| Location | Usage |
+|----------|--------|
+| `backend/app/main.py` | `Limiter(key_func=get_remote_address)` → `fastapi_app.state.limiter`; `SlowAPIMiddleware`; duplicate `RateLimitExceeded` handlers (lines ~346 and ~494) |
+| `backend/app/api/v1/endpoints/auth.py` | **Separate** module-level `Limiter(key_func=get_remote_address)` (to avoid circular imports per commit `7b115d6`) |
+
+**Routes with `@limiter.limit` (auth.py limiter instance):**
+
+| Route | Limit |
+|-------|-------|
+| `POST /login` | `5/minute` |
+| `POST /register` | `3/hour` |
+| `POST /access-token` | `5/minute` |
+| `POST /password-reset/request` | `3/hour` |
+
+**Not slowapi — additional Redis counters in `auth.py`:**
+
+- Registration: IP + email counters (`registration_rate_limit:ip:…`, `registration_rate_limit:email:…`) — **Redis-backed**, stricter than decorator alone ([`auth.py`](../../../backend/app/api/v1/endpoints/auth.py) ~424–597).
+- Resend verification: `resend_verification_rate_limit:…` — **Redis-backed** (~866–959).
+
+### Multi-worker risk (current slowapi wiring)
+
+Neither `main.py` nor `auth.py` passes `storage_uri` to `Limiter(...)`. Per [slowapi examples](https://github.com/laurentS/slowapi/blob/master/docs/examples.md), Redis requires explicit configuration; without it, **limits uses in-memory storage per process** ([slowapi README](https://github.com/laurentS/slowapi/blob/master/README.md) — *“memory as a fallback”*).
+
+Production runs Gunicorn + Uvicorn workers ([`docs/internal/ANALYSIS_FINDINGS.md`](../ANALYSIS_FINDINGS.md) — connection pooling / workers). **Per-worker memory limits multiply effective quota** (e.g. 5/minute × N workers).
+
+Additionally, **two `Limiter` instances** exist (`main.py` vs `auth.py`). [SlowAPI middleware](https://github.com/laurentS/slowapi/blob/master/slowapi/middleware.py) reads `app.state.limiter` (main’s instance) and exempts routes registered on *that* limiter’s `_route_limits`. Auth decorators register on **auth’s limiter**, so middleware and decorators may not share state — limits still run via decorator path but remain **in-memory on the auth limiter instance**.
+
+---
+
+## Why both were introduced (git + docs)
+
+| When | What | Evidence |
+|------|------|----------|
+| **2025-04-25** | Initial scaffold adds `fastapi-limiter>=0.1.6,<0.2.0` and `FastAPILimiter.init/close` in lifespan | Commit `47627b4` — *“Add initial project configuration and dependencies”*; `75c0586` — *“Initialize FastAPI RBAC project structure with Docker support”* |
+| **2025-06-03** | **slowapi** added for P0 rate limiting on auth; **fastapi-limiter not removed** | Commit `7b115d6` — *“feat: restore P0 Item #2 - Rate Limiting implementation”* (adds `slowapi==0.1.9`, `SlowAPIMiddleware`, `@limiter.limit` on auth routes) |
+| **2025-06-11** | Docs describe slowapi as the completed rate-limiting story | [`docs/internal/ANALYSIS_FINDINGS.md`](../ANALYSIS_FINDINGS.md) — slowapi on login/register/access-token/password-reset |
+| **2026-07-16** | Dependency policy freezes `fastapi-limiter` at 0.1.6 | [`docs/development/DEPENDENCY_UPGRADES.md`](../../development/DEPENDENCY_UPGRADES.md) Lane 2 CVE snapshot |
+| **2026-07-24** | Consolidation tracked as #64 | [Issue #64](https://github.com/mnaimfaizy/fastapi_rbac/issues/64) |
+
+**Interpretation:** `fastapi-limiter` came from the **original FastAPI RBAC template** (Redis cache/limit stack). `slowapi` was a **later, deliberate security addition** documented as production-ready, but the scaffold’s `FastAPILimiter` lifespan hook was never deleted and **no route was ever migrated to `RateLimiter`**.
+
+---
+
+## Recommendation for #64
+
+### Preferred path: **Keep slowapi, remove fastapi-limiter**
+
+Aligns with [#64 default](https://github.com/mnaimfaizy/fastapi_rbac/issues/64), current route usage, and [`DEPENDENCY_UPGRADES.md`](../../development/DEPENDENCY_UPGRADES.md) hard-stop note on middleware.
+
+**Implementation checklist:**
+
+1. Remove `fastapi-limiter` from `requirements.txt`.
+2. Remove `FastAPILimiter` import, `init/close`, and `user_id_identifier` from lifespan (keep Redis for cache, tokens, bespoke counters).
+3. **Single shared `Limiter`** on `app.state.limiter`; inject into auth router or import from a small `app/core/limiter.py` — eliminate duplicate instance in `auth.py`.
+4. **Configure Redis storage** for production, reusing existing Redis URL/settings:
+   ```python
+   limiter = Limiter(
+       key_func=get_remote_address,
+       storage_uri=settings.REDIS_URL,  # align with app Redis config
+   )
+   ```
+   ([slowapi Redis example](https://github.com/laurentS/slowapi/blob/master/docs/examples.md))
+5. Consider `SlowAPIASGIMiddleware` vs `SlowAPIMiddleware` ([examples](https://github.com/laurentS/slowapi/blob/master/docs/examples.md)) — optional perf/middleware deprecation note from Starlette.
+6. Deduplicate duplicate `RateLimitExceeded` handlers in `main.py`.
+7. Update tests (`test_rate_limiting_on_login`, etc.) to assert 429 with Redis-backed limiter in CI (Redis service already in CI per [`ANALYSIS_FINDINGS.md`](../ANALYSIS_FINDINGS.md)).
+8. Update [`DEPENDENCY_UPGRADES.md`](../../development/DEPENDENCY_UPGRADES.md) — remove “kept 0.1.6” debt; document slowapi + Redis as the single stack.
+
+### Alternative (not recommended unless new requirements appear)
+
+**Upgrade to fastapi-limiter 0.2.x and remove slowapi** — only if you need its 0.2 middleware/websocket model and accept a full rewrite of all `@limiter.limit` call sites plus PyrateLimiter backend wiring for Redis. Higher migration cost for no clear gain given slowapi already owns auth routes.
+
+---
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| **slowapi default in-memory with multiple workers** | **High** | Set `storage_uri` to Redis before/while removing fastapi-limiter ([slowapi examples](https://github.com/laurentS/slowapi/blob/master/docs/examples.md), [limits Redis URI](https://limits.readthedocs.io/en/stable/storage.html)) |
+| **Duplicate `Limiter` instances** | **Medium** | Consolidate to `app.state.limiter` used by all `@limiter.limit` decorators |
+| **Dual enforcement layers on register/resend** | **Low** | slowapi decorator + bespoke Redis counters — document both; optionally merge into slowapi `key_func` or separate limits later |
+| **slowapi websocket gap** | **Low** | No websocket routes use limiters today; use PyrateLimiter/fastapi-limiter 0.2 or custom logic if added |
+| **slowapi docs still say “alpha”** | **Low** | README also states production use at scale ([slowapi README](https://github.com/laurentS/slowapi/blob/master/README.md)); treat as doc drift |
+| **Removing fastapi-limiter while keeping Redis init assumptions** | **Low** | Redis remains required for tokens/cache/counters — only drop unused limiter init |
+| **fastapi-limiter 0.2 migration if chosen instead** | **High** | Full API rewrite; no drop-in from 0.1.6 ([compare](https://github.com/long2ice/fastapi-limiter/compare/v0.1.6...v0.2.0)) |
+
+---
+
+## References
+
+### fastapi-limiter
+
+- Repository: https://github.com/long2ice/fastapi-limiter
+- README (0.2 / master): https://github.com/long2ice/fastapi-limiter/blob/master/README.md
+- README (0.1.6): https://github.com/long2ice/fastapi-limiter/blob/v0.1.6/README.md
+- Compare 0.1.6 → 0.2.0: https://github.com/long2ice/fastapi-limiter/compare/v0.1.6...v0.2.0
+- CHANGELOG (0.1.x): https://github.com/long2ice/fastapi-limiter/blob/v0.1.6/CHANGELOG.md
+- PyPI: https://pypi.org/project/fastapi-limiter/
+- GitHub API (stars/activity): https://api.github.com/repos/long2ice/fastapi-limiter
+
+### slowapi
+
+- Repository: https://github.com/laurentS/slowapi
+- Documentation: https://slowapi.readthedocs.io/en/latest/
+- Examples (Redis, middleware): https://github.com/laurentS/slowapi/blob/master/docs/examples.md
+- Middleware source: https://github.com/laurentS/slowapi/blob/master/slowapi/middleware.py
+- PyPI: https://pypi.org/project/slowapi/
+- GitHub API: https://api.github.com/repos/laurentS/slowapi
+
+### Underlying engines
+
+- limits: https://limits.readthedocs.io/en/stable/
+- limits storage backends: https://limits.readthedocs.io/en/stable/storage.html
+- PyrateLimiter: https://github.com/vutran1710/PyrateLimiter
+
+### This repository
+
+- Issue #64: https://github.com/mnaimfaizy/fastapi_rbac/issues/64
+- [`docs/development/DEPENDENCY_UPGRADES.md`](../../development/DEPENDENCY_UPGRADES.md)
+- [`docs/internal/ANALYSIS_FINDINGS.md`](../ANALYSIS_FINDINGS.md)
+- [`backend/app/main.py`](../../../backend/app/main.py)
+- [`backend/app/api/v1/endpoints/auth.py`](../../../backend/app/api/v1/endpoints/auth.py)
+- Git: `47627b4` (initial fastapi-limiter), `7b115d6` (slowapi P0 implementation)

--- a/docs/reference/SECURITY_FEATURES.md
+++ b/docs/reference/SECURITY_FEATURES.md
@@ -45,28 +45,20 @@ const csrfToken = await csrfService.getCsrfToken();
 - `sanitize_url()`: URL validation and cleaning
 - `sanitize_search()`: Search query cleaning
 
-### 3. Rate Limiting
+### 3. HTTP Rate Limiting
 
-**Implementation**: `slowapi==0.1.9`
+**Implementation**: `slowapi` (sole HTTP rate limit library; see [ADR 0002](../adr/0002-slowapi-sole-http-rate-limit.md))
 
-**Protected Endpoints**:
+**Protected Endpoints** (HTTP rate limits, IP key):
 
 - **Login**: 5 attempts per minute
 - **Registration**: 3 attempts per hour
-- **Password Reset**: 3 attempts per hour
-- **Token Refresh**: 5 attempts per minute
+- **Password Reset request**: 3 attempts per hour
+- **Access token**: 5 attempts per minute
 
-**Configuration**:
+**Configuration**: shared `Limiter` in `app/core/rate_limit.py` (`get_remote_address`; Redis `storage_uri` outside testing).
 
-```python
-# Rate limiter with user identification
-limiter = Limiter(key_func=user_id_identifier)
-
-# Applied to endpoints
-@limiter.limit("5/minute")
-async def login_endpoint():
-    pass
-```
+Registration / resend-verification also use separate Redis **abuse counters** (not slowapi).
 
 ### 4. Enhanced Security Headers
 


### PR DESCRIPTION
## Summary
- Consolidate HTTP rate limiting onto **slowapi** only: remove unused `fastapi-limiter` scaffold init from lifespan and `requirements.txt`.
- Share one `Limiter` (`app/core/rate_limit.py`) with Redis `storage_uri` outside testing; keep Redis **abuse counters** for registration/resend unchanged.
- Add ADR 0002, `CONTEXT.md` glossary terms, dependency/security/Redis doc updates, research note, and unit tests that assert real **429** when the limiter is enabled.

## Test plan
- [x] `pytest backend/test/unit/test_rate_limit.py` (wiring + 429 on `/auth/access-token`)
- [x] Full backend unit suite (159 passed, 2 skipped)
- [x] `mypy` on touched app modules
- [x] CI green on this PR
- [ ] Optional smoke (non-testing): burst 6× `POST /api/v1/auth/access-token` → **429**, JSON `status: error`, code `rate_limit` (see ADR 0002)

Closes #64