### PR TITLE
docs(deploy): Hub runtime package and Oracle Always Free guide

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,3 +29,7 @@ A grouping construct for roles in this product's RBAC model.
 
 **Permission group**:
 A grouping construct for permissions in this product's RBAC model.
+
+**Hub runtime**:
+The deployable API package: published Docker Hub backend and worker images (including the Beat scheduler process), plus Postgres, Redis, and external SMTP. Does not include the admin UI.
+_Avoid_: Microservices (when meaning this package), full stack (when including the React frontend)

--- a/docs/adr/0003-hub-runtime-oracle-compose.md
+++ b/docs/adr/0003-hub-runtime-oracle-compose.md
@@ -1,0 +1,3 @@
+# Hub runtime validated on Oracle Always Free via Compose
+
+We need a free, intermittent way to prove the published Docker Hub API images work in a production-shaped environment (#96). We treat staging and production as the **same Hub runtime package** (backend + worker + Beat + Postgres + Redis; SMTP external; frontend out of scope for now), run it with Docker Compose on **Oracle Cloud Always Free**, terminate TLS with **Caddy** at `rbac-api.mnfprofile.com`, pin image tags by default, and document first-time OCI setup with Created/Last verified dates. Paid always-on VPS and free PaaS were rejected for maintainer validation: VPS costs money we do not want for start/stop testing; free PaaS cannot honestly host an always-on worker plus persistent Redis.

--- a/docs/deployment/hub-runtime/Caddyfile
+++ b/docs/deployment/hub-runtime/Caddyfile
@@ -1,0 +1,4 @@
+{$DOMAIN:rbac-api.mnfprofile.com} {
+	encode gzip
+	reverse_proxy api:8000
+}

--- a/docs/deployment/hub-runtime/bootstrap.sh
+++ b/docs/deployment/hub-runtime/bootstrap.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Hub runtime bootstrap: ensure .env secrets, then pull and start the package.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+ENV_FILE="${ENV_FILE:-.env}"
+EXAMPLE_FILE="env.example"
+
+gen_secret() {
+  # URL-safe for Redis/Celery URLs and env files
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 32
+  else
+    python3 -c "import secrets; print(secrets.token_hex(32))"
+  fi
+}
+
+set_kv_if_empty() {
+  local key="$1"
+  local value="$2"
+  if grep -qE "^${key}=$" "$ENV_FILE" || grep -qE "^${key}=[[:space:]]*$" "$ENV_FILE"; then
+    # Escape & for sed
+    local escaped
+    escaped="$(printf '%s' "$value" | sed -e 's/[&/\]/\\&/g')"
+    sed -i.bak "s|^${key}=.*|${key}=${escaped}|" "$ENV_FILE"
+    rm -f "${ENV_FILE}.bak"
+    echo "Generated ${key}"
+  fi
+}
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  if [[ ! -f "$EXAMPLE_FILE" ]]; then
+    echo "Missing ${EXAMPLE_FILE}. Run this script from docs/deployment/hub-runtime/." >&2
+    exit 1
+  fi
+  cp "$EXAMPLE_FILE" "$ENV_FILE"
+  echo "Created ${ENV_FILE} from ${EXAMPLE_FILE}"
+fi
+
+# Fill empty secret fields (DB password is mirrored to POSTGRES_* for the db service)
+for key in SECRET_KEY JWT_SECRET_KEY JWT_REFRESH_SECRET_KEY JWT_RESET_SECRET_KEY JWT_VERIFICATION_SECRET_KEY ENCRYPT_KEY DATABASE_PASSWORD FIRST_SUPERUSER_PASSWORD; do
+  set_kv_if_empty "$key" "$(gen_secret)"
+done
+
+# Mirror app DB settings into Postgres container env (compose uses env_file only)
+db_user="$(grep -E '^DATABASE_USER=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
+db_pass="$(grep -E '^DATABASE_PASSWORD=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
+db_name="$(grep -E '^DATABASE_NAME=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
+db_user="${db_user:-postgres}"
+db_name="${db_name:-fastapi_db}"
+
+sync_kv() {
+  local key="$1"
+  local value="$2"
+  local escaped
+  escaped="$(printf '%s' "$value" | sed -e 's/[&/\]/\\&/g')"
+  if grep -qE "^${key}=" "$ENV_FILE"; then
+    sed -i.bak "s|^${key}=.*|${key}=${escaped}|" "$ENV_FILE"
+  else
+    printf '%s=%s\n' "$key" "$value" >>"$ENV_FILE"
+  fi
+  rm -f "${ENV_FILE}.bak"
+}
+
+sync_kv "POSTGRES_USER" "$db_user"
+sync_kv "POSTGRES_PASSWORD" "$db_pass"
+sync_kv "POSTGRES_DB" "$db_name"
+# Broker URLs for private Redis (no auth); keep Celery on the Compose network
+sync_kv "CELERY_BROKER_URL" "redis://redis:6379/0"
+sync_kv "CELERY_RESULT_BACKEND" "redis://redis:6379/0"
+echo "Synced POSTGRES_* and Celery broker URLs in ${ENV_FILE}"
+
+# SMTP must be provided for full-flow validation
+if grep -qE "^SMTP_HOST=(smtp\.example\.com)?[[:space:]]*$" "$ENV_FILE" || grep -qE "^SMTP_HOST=$" "$ENV_FILE"; then
+  echo "WARNING: Set SMTP_* in ${ENV_FILE} before relying on email flows." >&2
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required. See oracle-always-free-setup.md." >&2
+  exit 1
+fi
+
+echo "Pulling images (IMAGE_TAG from ${ENV_FILE})..."
+docker compose --env-file "$ENV_FILE" -f compose.yml pull
+
+echo "Starting Hub runtime..."
+docker compose --env-file "$ENV_FILE" -f compose.yml up -d
+
+echo "Waiting for API health..."
+DOMAIN="$(grep -E '^DOMAIN=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
+DOMAIN="${DOMAIN:-rbac-api.mnfprofile.com}"
+
+for i in $(seq 1 60); do
+  if curl -fsS "https://${DOMAIN}/api/v1/health" >/dev/null 2>&1 || \
+     docker compose --env-file "$ENV_FILE" -f compose.yml exec -T api curl -fsS "http://localhost:8000/api/v1/health" >/dev/null 2>&1; then
+    echo "Hub runtime is up."
+    echo "API: https://${DOMAIN}/api/v1/health"
+    echo "OpenAPI: https://${DOMAIN}/docs"
+    echo "Superuser email is FIRST_SUPERUSER_EMAIL in ${ENV_FILE}"
+    exit 0
+  fi
+  sleep 5
+done
+
+echo "Timed out waiting for healthy API. Check: docker compose -f compose.yml logs" >&2
+exit 1

--- a/docs/deployment/hub-runtime/compose.yml
+++ b/docs/deployment/hub-runtime/compose.yml
@@ -1,0 +1,146 @@
+# Hub runtime package — pulls published Docker Hub images.
+# Usage (on the host, after env is ready):
+#   docker compose --env-file .env -f compose.yml up -d
+#
+# Services: caddy (public HTTPS) → api; worker + beat; db + redis (internal).
+# Secrets and broker URLs live in .env only (see env.example + bootstrap.sh).
+# Redis is not published; auth is omitted on the private Docker network so this
+# file stays free of password substitutions that trip secret scanners.
+
+name: fastapi-rbac-hub-runtime
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      DOMAIN: ${DOMAIN:-rbac-api.mnfprofile.com}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      api:
+        condition: service_healthy
+    networks:
+      - hub_runtime
+
+  api:
+    image: mnaimfaizy/fastapi-rbac-backend:${IMAGE_TAG:-v1.2.3}
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      MODE: production
+      DATABASE_HOST: db
+      REDIS_HOST: redis
+      REDIS_SSL: "false"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - hub_runtime
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+  worker:
+    image: mnaimfaizy/fastapi-rbac-worker:${IMAGE_TAG:-v1.2.3}
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      MODE: production
+      DATABASE_HOST: db
+      REDIS_HOST: redis
+      REDIS_SSL: "false"
+    command: ["/bin/bash", "/app/scripts/docker/start-worker.sh"]
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      api:
+        condition: service_started
+    networks:
+      - hub_runtime
+
+  beat:
+    image: mnaimfaizy/fastapi-rbac-worker:${IMAGE_TAG:-v1.2.3}
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      MODE: production
+      DATABASE_HOST: db
+      REDIS_HOST: redis
+      REDIS_SSL: "false"
+      CELERY_BEAT_SCHEDULER: celery.beat:PersistentScheduler
+      PYTHONPATH: /app
+    # Same image as worker; schedule file on a volume (do not mount over /app).
+    command:
+      [
+        "/bin/bash",
+        "-c",
+        "python ./app/backend_pre_start.py && exec celery -A app.celery_app beat --loglevel=info --schedule=/var/lib/celery/celerybeat-schedule.db",
+      ]
+    volumes:
+      - beat_schedule:/var/lib/celery
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      worker:
+        condition: service_started
+    networks:
+      - hub_runtime
+
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    # Credentials come from .env via env_file (POSTGRES_* set by bootstrap.sh).
+    env_file:
+      - .env
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - hub_runtime
+
+  redis:
+    image: redis:7.2-alpine
+    restart: unless-stopped
+    # Not published outside the Compose network; no --requirepass in this file.
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - hub_runtime
+
+volumes:
+  postgres_data:
+  redis_data:
+  beat_schedule:
+  caddy_data:
+  caddy_config:
+
+networks:
+  hub_runtime:
+    driver: bridge

--- a/docs/deployment/hub-runtime/env.example
+++ b/docs/deployment/hub-runtime/env.example
@@ -1,0 +1,69 @@
+#############################################
+# Hub runtime — copy to .env on the host
+#   cp env.example .env
+# Then run: ./bootstrap.sh
+#############################################
+
+# Pin a published release by default. Override to "latest" for a quick check.
+IMAGE_TAG=v1.2.3
+
+# Public API hostname (Caddy + Let's Encrypt)
+DOMAIN=rbac-api.mnfprofile.com
+
+# Application
+MODE=production
+PROJECT_NAME=fastapi-rbac
+DEBUG=false
+LOG_LEVEL=INFO
+USERS_OPEN_REGISTRATION=false
+
+# Leave empty in env.example — bootstrap.sh generates these if missing
+SECRET_KEY=
+JWT_SECRET_KEY=
+JWT_REFRESH_SECRET_KEY=
+JWT_RESET_SECRET_KEY=
+JWT_VERIFICATION_SECRET_KEY=
+ENCRYPT_KEY=
+
+# Tokens (production-oriented)
+ACCESS_TOKEN_EXPIRE_MINUTES=15
+REFRESH_TOKEN_EXPIRE_DAYS=7
+
+# Database (Compose service name: db)
+DATABASE_TYPE=postgresql
+DATABASE_HOST=db
+DATABASE_PORT=5432
+DATABASE_USER=postgres
+DATABASE_PASSWORD=
+DATABASE_NAME=fastapi_db
+# Postgres container also reads these (bootstrap mirrors DATABASE_*):
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=
+POSTGRES_DB=fastapi_db
+
+# Redis (Compose service name: redis) — private network only, no requirepass
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_PASSWORD=
+REDIS_SSL=false
+CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_RESULT_BACKEND=redis://redis:6379/0
+
+# First superuser (set strong values before first boot)
+FIRST_SUPERUSER_EMAIL=admin@example.com
+FIRST_SUPERUSER_PASSWORD=
+
+# CORS — API-only validation; add frontend origins when you bring the UI back
+BACKEND_CORS_ORIGINS=["https://rbac-api.mnfprofile.com"]
+
+# Email — required for full-flow validation (password reset, etc.)
+EMAILS_ENABLED=true
+EMAILS_FROM_EMAIL=no-reply@your-domain.com
+EMAILS_FROM_NAME=FastAPI RBAC
+EMAIL_VERIFICATION_URL=https://rbac-api.mnfprofile.com/verify-email
+FRONTEND_URL=https://rbac-api.mnfprofile.com
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_TLS=true
+SMTP_USER=
+SMTP_PASSWORD=

--- a/docs/deployment/hub-runtime/index.md
+++ b/docs/deployment/hub-runtime/index.md
@@ -1,0 +1,40 @@
+# Hub runtime
+
+Deploy the published Docker Hub **API package** (not the admin UI):
+
+- `mnaimfaizy/fastapi-rbac-backend`
+- `mnaimfaizy/fastapi-rbac-worker` (Celery **worker** and **beat** processes)
+
+plus Postgres, Redis, and external SMTP, behind Caddy HTTPS.
+
+This is the same topology for staging and production-style validation. Frontend hosting is out of scope here.
+
+## Contents
+
+| Artifact | Purpose |
+| --- | --- |
+| [`compose.yml`](./compose.yml) | One-package Compose: `caddy`, `api`, `worker`, `beat`, `db`, `redis` |
+| [`env.example`](./env.example) | Copy to `.env` on the host (never commit `.env`) |
+| [`bootstrap.sh`](./bootstrap.sh) | Generate empty secrets, pull images, start stack, wait for health |
+| [`Caddyfile`](./Caddyfile) | TLS for `DOMAIN` → `api:8000` |
+| [Oracle Always Free first-time setup](./oracle-always-free-setup.md) | Free VM path for maintainers |
+
+## Quick start (VM already prepared)
+
+```bash
+cd docs/deployment/hub-runtime
+cp env.example .env
+# Edit .env: IMAGE_TAG, DOMAIN, SMTP_*, FIRST_SUPERUSER_EMAIL
+chmod +x bootstrap.sh
+./bootstrap.sh
+```
+
+- Pin `IMAGE_TAG=vX.Y.Z` by default; set `IMAGE_TAG=latest` only for a quick check.
+- Default public host: `https://rbac-api.mnfprofile.com`
+- API health: `https://rbac-api.mnfprofile.com/api/v1/health`
+
+## Related
+
+- Research: [Hosting Docker Hub images](../../internal/research/hosting-docker-hub-images.md)
+- ADR: [0003 — Hub runtime on Oracle Always Free](../../adr/0003-hub-runtime-oracle-compose.md)
+- Issue: [#96](https://github.com/mnaimfaizy/fastapi_rbac/issues/96)

--- a/docs/deployment/hub-runtime/oracle-always-free-setup.md
+++ b/docs/deployment/hub-runtime/oracle-always-free-setup.md
@@ -1,0 +1,442 @@
+# Oracle Always Free — first-time Hub runtime setup
+
+**Created:** 2026-07-25
+**Last verified:** 2026-07-25
+
+Free, start/stop path to run the [Hub runtime](./index.md) package on Oracle Cloud Infrastructure (OCI) Always Free compute. Same Compose package can later run on any Docker VPS.
+
+Primary sources for limits and Console flows (re-check when this guide ages):
+
+- [Always Free Resources](https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier_topic-Always_Free_Resources.htm)
+- [Creating an Instance](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/launchinginstance.htm)
+- [Virtual Networking Wizards](https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/quickstartnetworking.htm)
+- [Security Lists](https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/securitylists.htm)
+
+## Staleness checklist — re-verify if any apply
+
+Re-check this guide and bump **Last verified** when:
+
+- [ ] This document is older than **6 months** since **Last verified**
+- [ ] OCI Always Free shapes, home-region rules, or Ampere OCPU/memory hours change
+- [ ] The Create Instance Console sections rename or reorder (Basic / Security / Networking / Storage)
+- [ ] Hub image tags, required env vars, or health paths change
+- [ ] Caddy / Docker Engine install steps fail on a fresh Ampere image
+- [ ] Default security-list or NSG behavior for ports 22/80/443 changes
+
+If several boxes apply, treat the guide as **out of date** until someone walks through a clean bring-up and updates the dates above.
+
+---
+
+## What you will end up with
+
+| Piece | Choice |
+| --- | --- |
+| Compute | Always Free **`VM.Standard.A1.Flex`** (Ampere / `arm64`), **2 OCPU / 12 GB** in the tenancy **home region** |
+| Package | [compose.yml](./compose.yml) — api, worker, beat, Postgres, Redis, Caddy |
+| DNS | `rbac-api.mnfprofile.com` → instance **public IPv4** |
+| TLS | Caddy + Let’s Encrypt |
+| SMTP | Your external provider (required for full email flows) |
+
+Frontend is not part of this package. Hub images are multi-arch (`linux/amd64` + `linux/arm64`), so Ampere is supported.
+
+### Always Free limits that matter for this guide (as of Last verified)
+
+Confirm live numbers on [Always Free Resources](https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier_topic-Always_Free_Resources.htm) before you click Create.
+
+| Resource | Always Free envelope (home region) |
+| --- | --- |
+| Ampere A1 | First **1,500 OCPU-hours** + **9,000 GB-hours** / month ≈ **2 OCPU + 12 GB** for Always Free–only tenancies (`VM.Standard.A1.Flex`) |
+| AMD micros | Up to **two** `VM.Standard.E2.1.Micro` (fallback if Ampere has no capacity) |
+| Block storage | **200 GB** total (boot + data volumes combined) |
+| Default boot volume | **50 GB** (counts toward the 200 GB) |
+| Idle reclaim | Always Free VMs may be reclaimed if underused for **7 days** (CPU / network / memory thresholds — see Oracle’s Idle Compute Instances note) |
+
+**Recommendation for Hub runtime:** one Ampere VM at **2 OCPU / 12 GB**, boot volume **100 GB** (leaves 100 GB headroom in the 200 GB pool). Do not create extra Always Free VMs you do not need.
+
+---
+
+## Prerequisites
+
+- Oracle Cloud account that still has Always Free eligibility
+- Work in the tenancy **home region** (Always Free compute must be created there)
+- Ability to create a DNS `A` record for `rbac-api.mnfprofile.com` (or your `DOMAIN`)
+- SMTP credentials for production-like email
+- A local SSH client (OpenSSH on Windows / macOS / Linux)
+- Optional but recommended: your own SSH key pair (`ssh-keygen -t ed25519`)
+
+Console tip: set the **region** selector (top right) to your **home region** before any of the steps below.
+
+---
+
+## 0. Compartment and region
+
+1. Sign in to the [OCI Console](https://cloud.oracle.com/).
+2. Confirm the region is your **home region**.
+3. Note the **compartment** you will use (usually the root compartment named like your tenancy, or a child compartment you created).
+   On list pages, use **List Scope → Compartment** so you do not create resources in the wrong place.
+
+---
+
+## 1. Create a VCN with internet connectivity (do this first)
+
+Oracle recommends creating the VCN **before** the first instance ([Creating an Instance](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/launchinginstance.htm)).
+
+Use the **Create a VCN with Internet Connectivity** wizard ([Virtual Networking Wizards](https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/quickstartnetworking.htm)). It creates:
+
+- A VCN
+- An **internet gateway**, NAT gateway, and service gateway
+- A **regional public subnet** (routed to the internet gateway)
+- A regional private subnet (not used for this guide)
+- Basic security-list rules (including SSH)
+
+### Steps
+
+1. Open the navigation menu → **Networking** → **Virtual cloud networks** (or **Networking** → **Overview**).
+2. Select **Start VCN Wizard** (sometimes under **Actions**).
+3. Choose **Create VCN with Internet Connectivity** → **Start VCN Wizard**.
+4. Fill in roughly:
+
+   | Field | Suggested value |
+   | --- | --- |
+   | VCN name | `vcn-hub-runtime` |
+   | Compartment | Your working compartment |
+   | VCN IPv4 CIDR | Default is fine (often `10.0.0.0/16`) |
+   | Public subnet name | `subnet-hub-runtime-public` |
+   | Public subnet CIDR | Default is fine (often `10.0.0.0/24`) |
+   | Private subnet | Keep defaults (unused for this guide) |
+   | Use DNS hostnames in this VCN | Enabled (recommended) |
+
+5. Review → **Create**.
+6. Wait until the workflow finishes, then open the new VCN and note:
+   - VCN name
+   - **Public** subnet name
+   - Default **Security List** name for the public subnet
+
+You only need this once. Later instances can reuse the same VCN and public subnet.
+
+---
+
+## 2. Security list: SSH + HTTP/HTTPS
+
+The wizard opens **SSH (22)** by default. Hub runtime also needs **80** and **443** for Caddy / Let’s Encrypt. Do **not** open Postgres `5432`, Redis `6379`, or API `8000` to the internet.
+
+1. Navigation menu → **Networking** → **Virtual cloud networks** → open `vcn-hub-runtime`.
+2. Under **Resources**, open **Security Lists** → open the security list attached to the **public** subnet (often **Default Security List for vcn-hub-runtime**).
+3. Select **Add Ingress Rules** and add **stateful** rules (leave **Stateless** cleared):
+
+| Description | Source type | Source CIDR | IP protocol | Destination port range |
+| --- | --- | --- | --- | --- |
+| SSH (prefer lock-down) | CIDR | `YOUR.PUBLIC.IP.0/32` or `0.0.0.0/0` | TCP | `22` |
+| HTTP (ACME + redirect) | CIDR | `0.0.0.0/0` | TCP | `80` |
+| HTTPS (API) | CIDR | `0.0.0.0/0` | TCP | `443` |
+
+Notes:
+
+- Prefer restricting SSH to your current public IP (`x.x.x.x/32`). If your ISP changes IPs, update the rule or you will lock yourself out.
+- Source port range: **All**.
+- If the wizard already created an SSH rule from `0.0.0.0/0`, you can edit it to your `/32` instead of adding a duplicate.
+- Optional: use a **Network Security Group (NSG)** instead of (or in addition to) the security list when you create the instance; rules are equivalent for this guide. See [Security Lists](https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/securitylists.htm).
+
+Egress: default “allow all” is fine so the VM can pull Docker Hub images and talk to SMTP / Let’s Encrypt.
+
+---
+
+## 3. Create the compute instance (granular Console settings)
+
+Navigation menu → **Compute** → **Instances** → set **List Scope** compartment → **Create instance**.
+
+The workflow has four sections matching Oracle’s docs: **Basic information**, **Security**, **Networking**, **Storage**, then review ([Creating an Instance](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/launchinginstance.htm)). Console labels can vary slightly; fill every required field even if the order differs.
+
+### 3.1 Basic information
+
+| Setting | Recommended value | Why |
+| --- | --- | --- |
+| Name | `hub-runtime-af` | Friendly label; OCID is the real id |
+| Create in compartment | Same as VCN | Keeps resources together |
+| Placement → Availability domain | Prefer **AD-2** or **AD-3** first if AD-1 often fails in your region; rotate on capacity errors | Always Free Ampere capacity is scarce |
+| Capacity type | **On-demand capacity** (default) | Do not use preemptible for this stack |
+| Fault domain | **Do not pick a fault domain** — leave Oracle to choose | Specifying one can worsen “Out of capacity” errors |
+
+#### Image
+
+1. Select **Change image**.
+2. Choose **Ubuntu** (or Oracle Linux if you prefer).
+3. Pick a current **Always Free–eligible** image for **aarch64 / Arm** (name usually includes `aarch64` or Arm).
+   Example target: recent **Canonical Ubuntu** LTS aarch64 marked Always Free Eligible.
+4. Accept Oracle’s terms if prompted → **Select image**.
+
+Do **not** pick an `amd64`/`x86_64`-only image for `VM.Standard.A1.Flex`.
+
+#### Shape
+
+1. Select **Change shape**.
+2. Shape series → **Ampere**.
+3. Select **`VM.Standard.A1.Flex`** (Always Free–eligible).
+4. Set sliders:
+
+   | Resource | Value |
+   | --- | --- |
+   | Number of OCPUs | **2** |
+   | Amount of memory (GB) | **12** |
+
+5. Leave burstable / extended memory **off**.
+6. Select **Select shape**.
+
+#### If you see: “Out of capacity for shape VM.Standard.A1.Flex in availability domain …”
+
+This is **regional host shortage**, not a bad image/SSH/VCN setting. Oracle’s own Always Free note: try another AD, or wait and retry ([Always Free Resources](https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier_topic-Always_Free_Resources.htm)).
+
+Do this in order:
+
+1. **Clear Fault domain** — in Placement → Advanced options, do **not** pin a fault domain; let OCI choose.
+2. **Switch Availability domain** — retry Create with **AD-2**, then **AD-3** (wording varies: `…-AD-2`, `…-AD-3`). Your error was **AD-1**; skip it for a while.
+3. **Retry at off-peak times** — capacity often frees overnight / weekends; keep the same form filled and click Create again later.
+4. **Shrink temporarily (optional)** — try **1 OCPU / 6 GB** once to grab a slot, then **Edit** → resize toward **2 / 12** when capacity appears (resize can also hit capacity).
+5. **AMD fallback (Always Free)** — Shape series → **Specialty and previous generation** → **`VM.Standard.E2.1.Micro`**, with an **x86_64** Always Free Ubuntu/Oracle Linux image. You may run **two** micros; the full Hub Compose stack is tight on ~1 GB RAM — expect swap pressure or a slimmed stack. Prefer Ampere when capacity returns.
+6. **Do not** “fix” capacity by picking a paid larger shape unless you accept leaving Always Free (costs apply above Always Free).
+
+Scripted retries (optional): some people poll `LaunchInstance` via OCI CLI/API across ADs; the Console rotate/retry loop above is enough for this guide.
+
+#### Basic advanced options (optional)
+
+Leave defaults unless you know you need them:
+
+- Instance metadata: prefer requiring IMDSv2 / authorization header if the image supports it
+- Initialization script: leave empty (we install Docker manually)
+- Oracle Cloud Agent plugins: defaults are fine
+
+### 3.2 Security
+
+| Setting | Recommended value |
+| --- | --- |
+| Shielded instance | **Off** (unless you have a requirement and the shape/image support it) |
+| Confidential computing | **Off** |
+| Security attributes (ZPR) | Skip unless your tenancy requires them |
+
+### 3.3 Networking (Primary VNIC)
+
+| Setting | Recommended value |
+| --- | --- |
+| Primary network | **Select existing virtual cloud network** → `vcn-hub-runtime` |
+| Subnet | **Select existing subnet** → **public** subnet `subnet-hub-runtime-public` |
+| Public IPv4 address | **Assign a public IPv4 address** → **Yes** (required for SSH + Caddy from the internet) |
+| Private IPv4 | Automatically assign (default) |
+| IPv6 | Off unless you already designed DNS/firewall for it |
+| Use NSGs | Optional; if used, attach an NSG that allows 22/80/443 as in §2 |
+| DNS record / hostname | Optional; e.g. hostname `hub-runtime` |
+
+**Do not** place this instance only in the **private** subnet for this guide (no public IP without Bastion).
+
+#### SSH keys
+
+Under **Add SSH keys**, pick one:
+
+| Option | When to use |
+| --- | --- |
+| **Upload public key files (.pub)** or **Paste public keys** | Recommended if you already have `~/.ssh/id_ed25519.pub` |
+| **Generate a key pair for me** | Fine for first time — **Save private key** immediately; you cannot download it later |
+| **No SSH keys** | Do **not** use — you will not be able to log in |
+
+Private key hygiene: store only on your workstation; never commit it to the repo.
+
+### 3.4 Storage
+
+| Setting | Recommended value |
+| --- | --- |
+| Boot volume size | Enable **Specify a custom boot volume size** → **100** GB |
+| Boot volume performance | **Balanced** (default) |
+| Encrypt with your own Vault key | Off (Oracle-managed encryption is enough for this validation host) |
+| In-transit encryption | Default / enabled if offered for VMs |
+| Additional block volumes | **None** for first bring-up (boot 100 GB is enough for images + Compose volumes) |
+
+Remember: boot size counts against the **200 GB** Always Free block budget.
+
+### 3.5 Review and create
+
+1. Review shape (**A1.Flex / 2 / 12**), image (aarch64), public subnet, **public IP = Yes**, SSH key present, boot **100 GB**.
+2. Select **Create**.
+3. Wait until lifecycle state is **Running** (can take a few minutes).
+4. On the instance details page, copy **Public IP address**.
+
+If creation fails with **Out of host capacity**, change availability domain and retry, wait and retry, or use the AMD micro fallback (see §3.1).
+
+---
+
+## 4. First SSH login
+
+From your workstation (replace IP and key path):
+
+```bash
+# Ubuntu images (typical):
+ssh -i ~/.ssh/id_ed25519 ubuntu@YOUR.PUBLIC.IP
+
+# Oracle Linux images (typical):
+ssh -i ~/.ssh/id_ed25519 opc@YOUR.PUBLIC.IP
+```
+
+Accept the host key fingerprint on first connect.
+
+If SSH times out:
+
+1. Instance is **Running**
+2. Security list / NSG allows TCP 22 from your IP
+3. You used the **public** subnet and assigned a **public** IP
+4. You are using the matching private key
+
+---
+
+## 5. Host firewall (inside the VM)
+
+OCI security lists are not the only filter. Configure the guest firewall so 80/443 are open **after** SSH is allowed.
+
+### Ubuntu (`ufw`)
+
+Ubuntu Minimal on OCI often has **no `ufw` package** yet (`ufw: command not found`). Install it first, allow SSH **before** enabling, then open HTTP/HTTPS:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y ufw
+sudo ufw allow OpenSSH
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw enable
+sudo ufw status
+```
+
+### Oracle Linux (`firewalld` — if active)
+
+```bash
+sudo firewall-cmd --permanent --add-service=ssh
+sudo firewall-cmd --permanent --add-service=http
+sudo firewall-cmd --permanent --add-service=https
+sudo firewall-cmd --reload
+```
+
+Some Oracle Linux images also use `iptables`/`nftables` rules from cloud-init; if ports still fail after security-list + firewalld, inspect `sudo iptables -L -n` / `sudo nft list ruleset`.
+
+---
+
+## 6. DNS
+
+Create an **A** record before Let’s Encrypt:
+
+```text
+rbac-api.mnfprofile.com  →  <instance public IPv4>
+```
+
+Check from your laptop:
+
+```bash
+nslookup rbac-api.mnfprofile.com
+# or: dig +short rbac-api.mnfprofile.com
+```
+
+Wait until it resolves to the instance IP before running `bootstrap.sh` (Caddy needs a matching hostname).
+
+---
+
+## 7. Install Docker Engine + Compose plugin
+
+On the instance, follow Docker’s current docs for your OS/arch:
+
+- [Install Docker Engine](https://docs.docker.com/engine/install/)
+- Confirm Compose v2 plugin: `docker compose version`
+
+Then:
+
+```bash
+sudo usermod -aG docker "$USER"
+# log out and back in (or new SSH session)
+docker run --rm hello-world
+```
+
+Use the **aarch64** engine packages on Ampere (Docker’s Ubuntu/Debian Arm64 repos).
+
+---
+
+## 8. Fetch the Hub runtime files
+
+```bash
+sudo apt-get update && sudo apt-get install -y git   # Ubuntu; use dnf on Oracle Linux
+git clone https://github.com/mnaimfaizy/fastapi_rbac.git
+cd fastapi_rbac/docs/deployment/hub-runtime
+```
+
+---
+
+## 9. Configure and bootstrap
+
+```bash
+cp env.example .env
+# Set at least:
+#   IMAGE_TAG=vX.Y.Z          # pin a release
+#   DOMAIN=rbac-api.mnfprofile.com
+#   FIRST_SUPERUSER_EMAIL=...
+#   SMTP_HOST / SMTP_PORT / SMTP_USER / SMTP_PASSWORD / EMAILS_FROM_EMAIL
+nano .env   # or vim
+
+chmod +x bootstrap.sh
+./bootstrap.sh
+```
+
+`bootstrap.sh` fills empty `SECRET_KEY` / DB / Redis / superuser password fields, pulls Hub images, starts Compose, and waits for API health.
+
+The API container entrypoint runs migrations and initial data (including the first superuser).
+
+---
+
+## 10. Smoke-test the full API flow
+
+```bash
+curl -fsS "https://rbac-api.mnfprofile.com/api/v1/health"
+# OpenAPI UI: https://rbac-api.mnfprofile.com/docs
+```
+
+Exercise login, a password-reset email (SMTP), and confirm worker/beat stay up:
+
+```bash
+docker compose --env-file .env -f compose.yml ps
+docker compose --env-file .env -f compose.yml logs -f worker beat
+```
+
+---
+
+## 11. Stop when you are not testing
+
+```bash
+cd ~/fastapi_rbac/docs/deployment/hub-runtime   # or your path
+docker compose --env-file .env -f compose.yml down
+```
+
+Optional: in Console → instance → **Stop** until the next test (avoids burning Always Free hours while idle; also reduces idle-reclaim risk from low utilization).
+
+Volumes retain Postgres/Redis/Caddy/Beat data until you `docker compose down -v` or delete the boot volume with the instance.
+
+---
+
+## Troubleshooting
+
+| Symptom | What to check |
+| --- | --- |
+| Out of capacity for `VM.Standard.A1.Flex` in AD-* | See §3.1 callout: no fault domain → other AD → retry later → optional 1/6 → AMD `E2.1.Micro` fallback; home region only |
+| Create instance: shape disabled | Image arch mismatch (need aarch64 for A1) or limit exhausted |
+| SSH timeout | Public IP assigned; public subnet; security list TCP/22; correct user (`ubuntu` / `opc`) |
+| ACME / TLS fails | DNS A record; OCI **and** guest firewall allow 80/443; `DOMAIN` matches cert name |
+| API unhealthy | `docker compose logs api`; DB/Redis health; `IMAGE_TAG` exists on Docker Hub |
+| Email never arrives | `EMAILS_ENABLED`, SMTP_*; provider allowlist for OCI egress IPs |
+| Redis auth errors | `REDIS_PASSWORD` in `.env` must match Compose `requirepass` |
+| Unexpected bill | Confirm resources stay within Always Free and home region; delete unused volumes |
+
+---
+
+## After first success
+
+1. Update **Last verified** at the top of this file to today’s date.
+2. Clear or refresh the staleness checklist.
+3. Prefer pinned `IMAGE_TAG` values that match [GitHub Releases](https://github.com/mnaimfaizy/fastapi_rbac/releases) / Docker Hub.
+
+## Related
+
+- [Hub runtime index](./index.md)
+- [Hosting research](../../internal/research/hosting-docker-hub-images.md)
+- [ADR 0003](../../adr/0003-hub-runtime-oracle-compose.md)

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -2,4 +2,6 @@
 
 This section covers how to deploy the application to production.
 
+- **[Hub runtime](./hub-runtime/index.md):** Pull published Docker Hub API images (backend + worker/beat) with Postgres, Redis, Caddy, and external SMTP. Start here for production-shaped validation.
+- **[Oracle Always Free setup](./hub-runtime/oracle-always-free-setup.md):** First-time free OCI environment for the Hub runtime (dated; re-verify when stale).
 - **[Production Deployment](./production-deployment-guide.md):** A step-by-step guide for deploying the application.

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -38,6 +38,10 @@ Go to: [`../development/DEVELOPER_SETUP.md`](../development/DEVELOPER_SETUP.md)
 
 Go to: [`../deployment/PRODUCTION_SETUP.md`](../deployment/PRODUCTION_SETUP.md)
 
+### 🐳 I want to validate published Hub API images (free Oracle path)
+
+Go to: [`../deployment/hub-runtime/index.md`](../deployment/hub-runtime/index.md) and [Oracle Always Free setup](../deployment/hub-runtime/oracle-always-free-setup.md)
+
 ### ❓ I'm having issues
 
 Browse: [`../troubleshooting/`](../troubleshooting/)

--- a/docs/internal/research/hosting-docker-hub-images.md
+++ b/docs/internal/research/hosting-docker-hub-images.md
@@ -1,0 +1,256 @@
+# Hosting the FastAPI RBAC Docker Hub images (staging + adopter path)
+
+**Date:** 2026-07-25
+**Issue:** [#96 — host microservices for production-feel testing](https://github.com/mnaimfaizy/fastapi_rbac/issues/96)
+**Repo:** [mnaimfaizy/fastapi_rbac](https://github.com/mnaimfaizy/fastapi_rbac)
+**Sources:** Primary only — Docker Hub READMEs, first-party platform docs/pricing, Oracle Always Free docs. Pricing is subject to change; figures below are as published on 2026-07-25 (or the page’s own “effective” date).
+**Status:** Research complete. Decisions locked in grill session (2026-07-25); see [ADR 0003](../../adr/0003-hub-runtime-oracle-compose.md) and [Hub runtime](../../deployment/hub-runtime/index.md).
+
+---
+
+## Scope and non-goals
+
+**In scope**
+
+- Easiest and free/cheapest ways (mid/late 2026) to run the three **published** Docker Hub production images:
+  - [`mnaimfaizy/fastapi-rbac-backend`](https://hub.docker.com/r/mnaimfaizy/fastapi-rbac-backend)
+  - [`mnaimfaizy/fastapi-rbac-frontend`](https://hub.docker.com/r/mnaimfaizy/fastapi-rbac-frontend)
+  - [`mnaimfaizy/fastapi-rbac-worker`](https://hub.docker.com/r/mnaimfaizy/fastapi-rbac-worker)
+- Two audiences: **maintainer staging** (public/staging dogfood) and **adopter “start here”** (cheap or preferred host).
+- Score platforms on Hub-image pull/run, Postgres/Redis/email supply, HTTPS/domain, free/cheap cost, ops complexity, staging vs adopter fit.
+
+**Locked decisions (do not re-litigate)**
+
+- Outcome shape C: both staging + adopter docs/scripts later.
+- Primary artifact = the three Hub images.
+- Redis/Postgres/Mailhog are **not** project product images ([#96](https://github.com/mnaimfaizy/fastapi_rbac/issues/96) handoff).
+
+**Out of scope**
+
+- Implementing hosting, Terraform, or CI deploy pipelines in this note.
+- Shipping official Postgres/Redis/SMTP images under the project namespace.
+- Choosing a production SLA topology for paying customers (staging-first).
+
+---
+
+## Runtime dependency model
+
+| Layer | Source | Role |
+| --- | --- | --- |
+| Backend | Hub `fastapi-rbac-backend` | FastAPI API (~port **8000**); needs `DATABASE_*`, `REDIS_*`, `SECRET_KEY`, CORS, optional SMTP ([Hub README](https://hub.docker.com/r/mnaimfaizy/fastapi-rbac-backend)) |
+| Frontend | Hub `fastapi-rbac-frontend` | React SPA served by **Nginx on port 80**; `VITE_API_BASE_URL` is typically **bake-time** ([Hub README](https://hub.docker.com/r/mnaimfaizy/fastapi-rbac-frontend)) |
+| Worker | Hub `fastapi-rbac-worker` | Celery; Redis broker/backend; same DB/Redis/SMTP access as backend ([Hub README](https://hub.docker.com/r/mnaimfaizy/fastapi-rbac-worker)) |
+| Postgres | **Not** a project Hub image | Postgres **12+** (managed or compose sidecar) |
+| Redis | **Not** a project Hub image | Redis **5+** — Celery + token allowlist/blacklist ([backend Hub README](https://hub.docker.com/r/mnaimfaizy/fastapi-rbac-backend)) |
+| SMTP | External or sidecar | Optional but required for password-reset email flows (`EMAILS_ENABLED`, `SMTP_*`) |
+
+```text
+[browser] --> frontend:80 (Nginx)
+                 |
+                 | API URL baked or proxied
+                 v
+              backend:8000 ----+---- Postgres
+                 |             |
+                 +---- Redis <-+---- Celery worker
+                 |
+              SMTP (optional but needed for resets)
+```
+
+---
+
+## Platform shortlist (viability)
+
+| Platform | Viability (1–2 sentences) |
+| --- | --- |
+| **Hetzner Cloud + Docker Compose** | Strongest cost/control fit: pull all three Hub images + official Postgres/Redis sidecars on one always-on VM; HTTPS via Caddy/Traefik/Let’s Encrypt. CX23 from **€5.49 / $6.49 per month excl. IPv4** (DE/FI, post–15 Jun 2026 adjustment) ([Hetzner price adjustment](https://docs.hetzner.com/general/infrastructure-and-availability/price-adjustment/)). |
+| **DigitalOcean Droplet + Compose** | Same topology as Hetzner; clearer US docs/branding. Basic Droplets from **$4/mo** (512 MiB — too small) / practical staging from **$12–24/mo** (2–4 GiB) ([DO Droplet pricing](https://www.digitalocean.com/pricing/droplets)). |
+| **Oracle Cloud Always Free + Compose** | Still real: Ampere A1 **1,500 OCPU-hours + 9,000 GB-hours/mo** (≈ **2 OCPU / 12 GB** for Always Free tenancies) plus two AMD micros ([OCI Always Free](https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier_topic-Always_Free_Resources.htm)). Viable **$0** path: Hub `:latest` is **multi-arch (`amd64` + `arm64`)** (verified 2026-07-25), so Ampere is image-compatible; account capacity and ops friction remain. |
+| **Coolify on a VPS** | Self-hosted PaaS control plane on *your* server; free OSS, Cloud add-on from **$5/mo**; Docker-compatible services + Let’s Encrypt ([Coolify intro](https://coolify.io/docs/get-started/introduction)). Eases adopter UX without abandoning VPS economics. |
+| **Railway** | Native **public Docker Hub** deploy + Postgres/Redis templates + auto SSL ([quick start](https://docs.railway.com/quick-start), [Postgres](https://docs.railway.com/databases/postgresql), [Redis](https://docs.railway.com/databases/redis), [public networking](https://docs.railway.com/networking/public-networking)). Free/$1 credit is **not** enough for this stack; Hobby **$5/mo** + usage is the realistic floor ([plans](https://docs.railway.com/pricing/plans)). |
+| **Render** | Excellent Hub-image support for web/worker ([deploy image](https://render.com/docs/deploying-an-image)) and managed Postgres/Key Value, but **free web sleeps**, **no free workers**, free Postgres **expires in 30 days**, free Redis **non-persistent** ([free docs](https://render.com/docs/free)) — poor for Celery + allowlist. Paid staging ≈ tens of USD/mo. |
+| **Fly.io** | Can deploy Hub images via `[build].image` / `fly deploy --image` ([deploy](https://fly.io/docs/launch/deploy/)); Machines PAYG (~**$2+/mo** per tiny always-on VM) ([pricing](https://fly.io/docs/about/pricing/)). Managed Postgres starts at **$38/mo** ([MPG](https://fly.io/docs/mpg/)) — expensive for staging unless you self-host Postgres on Machines + Upstash Redis. |
+| **Briefly dismissed / optional** | **Google Cloud Run / Azure Container Apps / AWS Lightsail-ECS**: can run containers but multi-service + always-on worker + Redis/Postgres wiring is more complex/costly than VPS or Railway for this stack. **Kamal**: deploy tool onto a VPS you already own — orthogonal to “where to host.” **Northflank / Zeabur / Porter**: not required for cheapest/easiest defaults; evaluate later if a template marketplace is desired. |
+
+---
+
+## Comparison table
+
+Ease / suitability scored **High / Med / Low** for *this* three-image + Postgres + Redis + always-on worker stack. Costs are **rough monthly floors** for small staging (3 app containers + Postgres + Redis); VAT, domains, and SMTP extra. **Subject to change.**
+
+| Platform | Ease | Free/cheap cost | Hub-image fit | Managed Postgres/Redis | HTTPS | Staging suitability | Adopter suitability | Notes / caveats |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **Hetzner + Compose** | Med | **~€6–10/mo** (CX23 €5.49 + Primary IPv4 **€0.50**/mo; excl. VAT) | **High** — `docker pull` public Hub | Sidecars (you run official images) or external managed | DIY (Caddy/Traefik + LE) | **High** | **High** (clear compose runbook) | Best $/always-on; you own ops. IPv4 is an add-on ([servers overview](https://docs.hetzner.com/cloud/servers/overview/)) |
+| **DO Droplet + Compose** | Med | **~$12–24/mo** practical | **High** | Sidecars or DO Managed DB (extra) | DIY or DO LB | **High** | **High** | Similar to Hetzner; more $ |
+| **Oracle Always Free + Compose** | Low–Med | **$0** (Always Free limits) | **High** (`arm64` + `amd64` on Hub) | Sidecars on free VM | DIY | Med (capacity/friction) | Med (account + ops) | Ampere now **2 OCPU / 12 GB** ([docs](https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier_topic-Always_Free_Resources.htm)); not “easy” |
+| **Coolify + VPS** | Med–High UI | VPS cost (+ optional Coolify Cloud **$5/mo**) | **High** (Docker-compatible) | App-managed containers or external | Built-in LE ([intro](https://coolify.io/docs/get-started/introduction)) | **High** | **High** if docs lead with Coolify | Control-plane worth it for less YAML |
+| **Railway** | **High** | Trial **$5** once; Free **$1**/mo useless for stack; Hobby **$5** + usage often **~$10–25+** | **High** public Hub ([quick start](https://docs.railway.com/quick-start)) | Yes (templates; usage-billed) | Auto SSL + custom domain ([networking](https://docs.railway.com/networking/public-networking)) | **High** (Hobby+) | **High** for PaaS preferrers | Free: 0.5 GB RAM/svc, 1 vol/project, peak-hour deploy limits ([plans](https://docs.railway.com/pricing/plans), [volumes](https://docs.railway.com/volumes/reference), [deploys](https://docs.railway.com/deployments/reference)) |
+| **Render** | High UI | Free unsuitable; paid floor ~**$30–40+**/mo (2× Starter web/worker + Basic-256 Postgres + Starter KV) | **High** ([image deploy](https://render.com/docs/deploying-an-image)) | Yes ([pricing](https://render.com/pricing)) | Auto TLS + custom domains | Med (cost) | Med | Free web **spins down 15 min**; workers **not free**; free PG **30-day**; free KV **memory-only**; free web **blocks SMTP 25/465/587** ([free](https://render.com/docs/free)) |
+| **Fly.io** | Med | Machines ~**$6–15** for 3 small VMs; MPG **$38+**; Upstash Redis free/PAYG | **High** (`image` in fly.toml) | MPG expensive; Upstash Redis ([docs](https://fly.io/docs/upstash/redis/)); self-host PG on Machines | Shared IPv4 + certs (first 10 hostnames free) ([pricing](https://fly.io/docs/about/pricing/)) | Med | Med | Celery polling can burn Upstash PAYG — prefer fixed Redis plan ([Fly Redis note](https://fly.io/docs/upstash/redis/)) |
+
+---
+
+## Recommended default for maintainer staging
+
+**Primary recommendation: Hetzner Cloud CX23 (or CX33 if RAM is tight) + Docker Compose pulling the three Hub images + official `postgres` / `redis` sidecars + a reverse proxy for HTTPS.**
+
+**Rationale**
+
+1. **Always-on by default** — Celery worker and Redis-backed auth allowlists need processes that do not sleep. Render’s free web **spins down after 15 minutes idle** and **background workers have no Free instance type** ([Render free](https://render.com/docs/free); worker pricing starts at Starter **$7/mo** on [Render pricing](https://render.com/pricing)).
+2. **Cheapest realistic always-on envelope** — CX23 is **€5.49 / $6.49 per month excl. IPv4** in DE/FI after the 15 Jun 2026 adjustment ([Hetzner docs](https://docs.hetzner.com/general/infrastructure-and-availability/price-adjustment/)). Primary IPv4 adds **€0.50/mo** excl. VAT ([servers overview](https://docs.hetzner.com/cloud/servers/overview/)). Community/spec sheets describe CX23 as **2 vCPU / 4 GB / 40 GB** (confirm in Hetzner Console at order time). That is enough for a small staging compose stack; upgrade to CX33 (**€8.49 / $9.99** excl. IPv4) if memory pressure appears.
+3. **Hub images are first-class** — staging exercises the same artifacts adopters pull (`docker pull mnaimfaizy/...`), matching [#96](https://github.com/mnaimfaizy/fastapi_rbac/issues/96) and Hub READMEs.
+4. **Postgres/Redis as sidecars** — aligns with the locked decision not to publish those as product images; use upstream official images or later swap to managed DB without changing Hub app images.
+5. **HTTPS** — terminate TLS on Caddy or Traefik with Let’s Encrypt on a staging domain you control (e.g. `staging.example.com`).
+
+**Optional staging UX upgrade:** install **Coolify** on the same VPS (self-host free) for UI deploys, Hub image pulls, and automated certificates ([Coolify intro](https://coolify.io/docs/get-started/introduction)) — still recommend Compose/Coolify *on Hetzner* rather than a multi-$ PaaS for maintainer dogfood budget.
+
+**SMTP for staging:** use a free transactional provider with SMTP relay (e.g. Resend Free: **3,000 emails/mo**, **100/day**, SMTP included on all plans — [Resend pricing](https://resend.com/pricing)), or disable email features and document that password reset is unverified on that environment.
+
+---
+
+## Recommended default for adopter cheapest clear start
+
+**Primary recommendation (cheapest + clearest): same path as staging — “one small VPS + Compose file that pulls Hub images.”**
+
+Lead adopters with a short runbook:
+
+1. Create a VPS (≥ **2 vCPU / 4 GB**; Hetzner CX23-class or DigitalOcean **$12–24** Droplet).
+2. Install Docker Engine + Compose plugin.
+3. Copy a project-provided `compose` (future artifact) that references:
+   - `mnaimfaizy/fastapi-rbac-backend:latest` (or pinned `vX.Y.Z`)
+   - `mnaimfaizy/fastapi-rbac-frontend:…` (**rebuild or pin a tag baked for their API URL** — see constraints)
+   - `mnaimfaizy/fastapi-rbac-worker:…`
+   - `postgres:16` (or 12+) and `redis:7` (or 5+)
+4. Set env from Hub / `backend/.env.example` placeholders.
+5. Point DNS + enable HTTPS via Caddy/Traefik (or Coolify).
+
+**Why not lead with “free PaaS”?** Render Free and Railway Free/$1 credit **cannot** honestly host this full stack always-on (sleeping web, no free workers, free PG expiry, free Redis non-persistence, $1 credit, 1 volume on Railway Free — sources in table). Marketing “free” would set adopters up to fail on Celery + Redis auth.
+
+**Secondary adopter path (if they refuse SSH/VPS):** **Railway Hobby** — deploy three public Hub images + Postgres + Redis templates, generate domains, set variables ([Railway quick start — Docker image](https://docs.railway.com/quick-start), [plans](https://docs.railway.com/pricing/plans)). Expect **at least $5/mo** subscription and often **more** once five always-on services burn past the included **$5** usage credit (RAM **$10/GB-mo**, CPU **$20/vCPU-mo**, egress **$0.05/GB** — [plans](https://docs.railway.com/pricing/plans)).
+
+---
+
+## Alternative paths
+
+| If you want… | Path | Rough cost | Caveat |
+| --- | --- | --- | --- |
+| **Fully managed PaaS** | Railway Hobby (or Render paid: web + worker + Postgres + Key Value) | Railway ~**$10–25+**/mo; Render ~**$30–40+**/mo | Frontend bake-time URL still friction; watch usage |
+| **$0 compute** | Oracle Always Free Ampere (≤ **2 OCPU / 12 GB**) + Compose | **$0** | Account approval, capacity, higher ops (images are `arm64`-capable); limits reduced vs older 4/24 folklore ([OCI Always Free](https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier_topic-Always_Free_Resources.htm), [Free Tier overview](https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier.htm)) |
+| **PaaS UX on cheap metal** | Coolify (self-host) on Hetzner/DO | VPS only, or +**$5** Coolify Cloud | Still a server to patch |
+| **Fly-native** | Three Fly apps from Hub images + self-hosted Postgres Machine + Upstash Redis | Highly variable; MPG alone **$38+** | Prefer fixed Upstash plan if Celery polls aggressively ([Fly Redis](https://fly.io/docs/upstash/redis/)) |
+| **US-branded VPS** | DigitalOcean Droplet + Compose | **$12–24**/mo | Same runbook as Hetzner |
+
+---
+
+## Hosting constraints specific to this product
+
+### 1. Frontend bake-time API URL
+
+Hub frontend README states `VITE_API_BASE_URL` is used at **docker build** for Nginx/app config; runtime override may need “a more complex setup or a custom entrypoint,” otherwise **rebuild** with the correct build-arg ([frontend Hub](https://hub.docker.com/r/mnaimfaizy/fastapi-rbac-frontend)).
+
+**Hosting implication:** platforms that only inject runtime env vars do **not** fix a published `latest` image built for `localhost` or a wrong API host. Staging/adopter docs must either:
+
+- pin/rebuild frontend per environment API URL, or
+- document a reverse-proxy same-origin layout (`/api` → backend) and an image built for that, or
+- ship a future runtime-config entrypoint (open product decision — not in this research).
+
+### 2. Always-on Celery worker
+
+Worker has **no public HTTP port**; it must stay running and share Redis/DB with the API ([worker Hub](https://hub.docker.com/r/mnaimfaizy/fastapi-rbac-worker)). Platforms that sleep free web tiers or omit free background workers (Render Free) are a bad fit ([Render free](https://render.com/docs/free)).
+
+### 3. Redis for auth allowlist / blacklist + Celery
+
+Backend Hub documents Redis for token blacklisting; worker uses Redis as Celery broker/backend. Free Key Value on Render is **in-memory only** and **loses data on restart** ([Render free](https://render.com/docs/free)) — unsuitable for auth token state. Prefer persistent Redis (compose volume, Railway Redis, Upstash paid/fixed, etc.).
+
+### 4. SMTP
+
+Password reset and similar flows need `EMAILS_ENABLED` + `SMTP_*` ([backend Hub](https://hub.docker.com/r/mnaimfaizy/fastapi-rbac-backend)). Render Free web services **cannot send outbound traffic on ports 25, 465, or 587** ([Render free](https://render.com/docs/free)). Prefer HTTP-based email APIs or SMTP on paid/VPS hosts. Resend Free includes SMTP with daily caps ([Resend pricing](https://resend.com/pricing)).
+
+### 5. CORS + dual public hostnames
+
+If frontend and API are on different origins, `BACKEND_CORS_ORIGINS` must list the frontend origin ([backend Hub](https://hub.docker.com/r/mnaimfaizy/fastapi-rbac-backend)). Same-origin proxy reduces CORS pain and can simplify frontend API URL.
+
+### 6. Image platform / size
+
+Render requires `linux/amd64` and compressed image ≤ **10 GB** ([deploying an image](https://render.com/docs/deploying-an-image)). Railway Free/Trial image size cap **4 GB** ([plans](https://docs.railway.com/pricing/plans)). All three published Hub `:latest` tags expose **`linux/amd64` and `linux/arm64`** (verified 2026-07-25 with `docker manifest inspect` for backend, frontend, and worker) — Oracle Ampere and Hetzner CAX are image-compatible; still confirm digest/tag at deploy time.
+
+---
+
+## Open decisions (for the next grill session)
+
+1. **Managed vs compose sidecars for Postgres/Redis on staging** — sidecars keep cost ~VPS-only; managed improves backups/ops at higher $.
+2. **Staging topology** — single VPS compose vs Railway project vs Coolify-on-VPS; one public staging URL vs separate API + web hostnames.
+3. **Domain / HTTPS** — which domain for maintainer staging; Caddy vs Traefik vs Coolify LE; wildcard vs single host.
+4. **SMTP provider** — Resend Free vs other; whether staging enables email at all.
+5. **Frontend config strategy** — rebuild-per-env vs same-origin Nginx proxy vs invest in runtime config in the published image.
+6. **Doc / script entrypoint** — single “Deploy Hub images” guide under `docs/deployment/` with VPS Compose first and Railway appendix; version-pin tags vs `:latest`.
+7. **Coolify worth it?** — extra moving part for maintainers vs much better adopter UX.
+8. **Oracle Always Free as documented “$0 path”** — document with hard caveats, or omit from primary path to avoid support burden.
+9. **Worker scaling / Beat** — single worker enough for staging? Celery Beat container needed?
+10. **Secrets & first superuser** — how staging seeds `SECRET_KEY` / `FIRST_SUPERUSER_*` without committing secrets.
+
+---
+
+## Sources appendix
+
+### Product / issue
+
+- Issue #96: https://github.com/mnaimfaizy/fastapi_rbac/issues/96
+- Backend image: https://hub.docker.com/r/mnaimfaizy/fastapi-rbac-backend
+- Frontend image: https://hub.docker.com/r/mnaimfaizy/fastapi-rbac-frontend
+- Worker image: https://hub.docker.com/r/mnaimfaizy/fastapi-rbac-worker
+
+### Hetzner / DigitalOcean / Oracle (VPS)
+
+- Hetzner price adjustment (15 Jun 2026), CX23 **€5.49 / $6.49** excl. IPv4 (DE/FI): https://docs.hetzner.com/general/infrastructure-and-availability/price-adjustment/
+- Hetzner Cloud product: https://www.hetzner.com/cloud/
+- Hetzner Cloud FAQ (shared vs dedicated): https://docs.hetzner.com/cloud/servers/faq/
+- DigitalOcean Droplet pricing: https://www.digitalocean.com/pricing/droplets
+- DigitalOcean Droplet billing docs: https://docs.digitalocean.com/products/droplets/details/pricing/
+- Oracle Always Free resources: https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier_topic-Always_Free_Resources.htm
+- Oracle Free Tier overview: https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier.htm
+
+### Coolify
+
+- Introduction (self-host free / Cloud from $5): https://coolify.io/docs/get-started/introduction
+
+### Railway
+
+- Plans & resource prices: https://docs.railway.com/pricing/plans
+- Free trial ($5 / 30 days → Free $1/mo): https://docs.railway.com/pricing/free-trial
+- Deploy from Docker image: https://docs.railway.com/quick-start
+- Services / Hub images: https://docs.railway.com/services
+- PostgreSQL template: https://docs.railway.com/databases/postgresql
+- Redis template: https://docs.railway.com/databases/redis
+- Public networking / SSL: https://docs.railway.com/networking/public-networking
+- Volume limits (Free: 1 volume/project): https://docs.railway.com/volumes/reference
+- Free-tier peak-hour deploy restriction: https://docs.railway.com/deployments/reference
+
+### Render
+
+- Pricing (web/worker/Postgres/Key Value): https://render.com/pricing
+- Free instance limitations (sleep, PG 30-day, KV non-persistent, SMTP ports): https://render.com/docs/free
+- Deploy prebuilt Docker image: https://render.com/docs/deploying-an-image
+
+### Fly.io / Upstash / email
+
+- Fly resource pricing: https://fly.io/docs/about/pricing/
+- Fly deploy / image: https://fly.io/docs/launch/deploy/
+- Fly Managed Postgres pricing: https://fly.io/docs/mpg/
+- Upstash Redis on Fly: https://fly.io/docs/upstash/redis/
+- Upstash Redis pricing (Free 256 MB / 500K commands): https://upstash.com/pricing/redis
+- Resend pricing (Free 3,000/mo, SMTP): https://resend.com/pricing
+
+---
+
+## Confidence / source gaps
+
+| Gap | Impact |
+| --- | --- |
+| Exact **maintainer** monthly Railway/Fly bill for *this* image set not measured live | Cost bands are rate-card estimates, not invoices |
+| Hetzner Console live SKU page did not expose CX23 RAM in the fetched marketing HTML; **2 vCPU / 4 GB** taken from Hetzner ecosystem listings + price-adjustment SKU — **confirm in Console** before buying | Sizing risk |
+| Linode/Akamai pricing page blocked from this research environment | Omitted from table; treat as DO-class VPS alternative |
+| Hub `:latest` **multi-arch** verified (`amd64` + `arm64`) for all three images on 2026-07-25 | Oracle Ampere / Hetzner CAX are image-OK; pin digests in runbooks |
+| Coolify “deploy Docker Hub image” wizard specifics not deeply fetched (intro confirms Docker-compatible deploy) | Coolify steps should be validated hands-on before docs |
+| Product may later add runtime frontend config — would change PaaS friction | Track as open decision #5 |
+
+**Do not implement hosting from this note until open decisions are grilled and a doc/script entrypoint is chosen.**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,9 @@ nav:
       - "Knowledge Graph (graphify)": "agents/graphify.md"
   - "Deployment":
       - "Overview": "deployment/index.md"
+      - "Hub runtime":
+          - "Overview": "deployment/hub-runtime/index.md"
+          - "Oracle Always Free setup": "deployment/hub-runtime/oracle-always-free-setup.md"
       - "Production Deployment": "deployment/production-deployment-guide.md"
       - "Quick Release Guide": "deployment/QUICK_RELEASE_GUIDE.md"
       - "Release Process": "deployment/RELEASE_PROCESS.md"


### PR DESCRIPTION
## Summary
- Add a Hub runtime Compose package (published backend/worker images + Beat, Postgres, Redis, Caddy) for production-shaped API validation without the frontend.
- Document first-time Oracle Always Free setup with Created/Last verified dates and a staleness checklist (`rbac-api.mnfprofile.com`).
- Capture decisions in ADR 0003, CONTEXT glossary term, hosting research note, and MkDocs/getting-started links (#96).

## Test plan
- [ ] Review `docs/deployment/hub-runtime/` artifacts (compose, env.example, bootstrap, Caddyfile, Oracle guide)
- [ ] Confirm MkDocs nav builds for Hub runtime pages
- [ ] (Optional) Bring up on Always Free after DNS for `rbac-api.mnfprofile.com` and smoke `/api/v1/health`

Closes #96

Made with [Cursor](https://cursor.com)