### PR TITLE
feat(deploy): Admin UI host cPanel release deploy

### DIFF
--- a/.github/workflows/admin-ui-cpanel-deploy.yml
+++ b/.github/workflows/admin-ui-cpanel-deploy.yml
@@ -1,0 +1,100 @@
+# Admin UI host → cPanel (static dist/)
+# Triggers: v* tags (same release cadence as Docker Hub) + workflow_dispatch.
+# Not on every push to main. Separate named jobs — do not collapse into one job.
+name: Admin UI cPanel Deploy
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build (tag, branch, or SHA). Empty = current default branch."
+        required: false
+        default: ""
+
+concurrency:
+  group: admin-ui-cpanel-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.ref || github.sha) || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build-admin-ui-assets:
+    name: Build Admin UI Assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref != '' && github.event.inputs.ref || github.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: react-frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: react-frontend
+        run: npm ci --legacy-peer-deps
+
+      - name: Build production assets
+        working-directory: react-frontend
+        env:
+          VITE_API_BASE_URL: ${{ vars.ADMIN_UI_VITE_API_BASE_URL }}
+        run: |
+          export VITE_API_BASE_URL="${VITE_API_BASE_URL:-https://rbac-api.mnfprofile.com/api/v1}"
+          echo "VITE_API_BASE_URL=${VITE_API_BASE_URL}"
+          npm run build
+
+      - name: Ensure SPA .htaccess in dist
+        working-directory: react-frontend
+        run: |
+          if [ ! -f dist/.htaccess ]; then
+            cp public/.htaccess dist/.htaccess
+          fi
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: admin-ui-dist
+          path: react-frontend/dist/
+          retention-days: 7
+
+  upload-admin-ui-cpanel:
+    name: Upload Admin UI to cPanel
+    needs: build-admin-ui-assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: admin-ui-dist
+          path: dist
+
+      - name: FTP sync to cPanel document root
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
+        with:
+          server: ${{ secrets.CPANEL_FTP_SERVER }}
+          username: ${{ secrets.CPANEL_FTP_USERNAME }}
+          password: ${{ secrets.CPANEL_FTP_PASSWORD }}
+          local-dir: dist/
+          server-dir: ${{ secrets.CPANEL_FTP_SERVER_DIR }}
+          dangerous-clean-slate: false
+
+  smoke-admin-ui-https:
+    name: Smoke Admin UI HTTPS
+    needs: upload-admin-ui-cpanel
+    runs-on: ubuntu-latest
+    steps:
+      - name: HTTPS reachability check
+        env:
+          ADMIN_UI_PUBLIC_URL: ${{ vars.ADMIN_UI_PUBLIC_URL }}
+        run: |
+          set -euo pipefail
+          ADMIN_UI_PUBLIC_URL="${ADMIN_UI_PUBLIC_URL:-https://rbac.mnfprofile.com}"
+          echo "Checking ${ADMIN_UI_PUBLIC_URL}/"
+          curl -fsSI --max-time 30 "${ADMIN_UI_PUBLIC_URL}/" | head -n 20
+          curl -fsS --max-time 30 "${ADMIN_UI_PUBLIC_URL}/" -o /dev/null
+          echo "Admin UI host smoke OK"

--- a/.github/workflows/admin-ui-cpanel-deploy.yml
+++ b/.github/workflows/admin-ui-cpanel-deploy.yml
@@ -76,11 +76,11 @@ jobs:
       - name: FTP sync to cPanel document root
         uses: SamKirkland/FTP-Deploy-Action@v4.3.6
         with:
-          server: ${{ secrets.CPANEL_FTP_SERVER }}
-          username: ${{ secrets.CPANEL_FTP_USERNAME }}
-          password: ${{ secrets.CPANEL_FTP_PASSWORD }}
+          server: ${{ secrets.UI_FTP_SERVER }}
+          username: ${{ secrets.UI_FTP_USERNAME }}
+          password: ${{ secrets.UI_FTP_PASSWORD }}
           local-dir: dist/
-          server-dir: ${{ secrets.CPANEL_FTP_SERVER_DIR }}
+          server-dir: ${{ secrets.UI_FTP_SERVER_DIR }}
           dangerous-clean-slate: false
 
   smoke-admin-ui-https:

--- a/.github/workflows/release-tag-on-merge.yml
+++ b/.github/workflows/release-tag-on-merge.yml
@@ -3,10 +3,11 @@ name: Release Tag on Merge
 # When a Release PR (head branch release/v*) is merged into main, create the
 # annotated SemVer tag and a GitHub Release. Branch name is the version SSOT.
 #
-# Docker Publish: tags pushed with GITHUB_TOKEN do not start other workflows, so
-# this job dispatches docker-publish.yml via workflow_dispatch after the tag
-# exists. Manual paths remain: push a v* tag yourself, or Run workflow on
-# Docker Publish. Do not also trigger on release: published (avoids double builds).
+# Downstream workflows: tags pushed with GITHUB_TOKEN do not start other
+# workflows, so this job dispatches docker-publish.yml and
+# admin-ui-cpanel-deploy.yml via workflow_dispatch after the tag exists.
+# Manual paths remain: push a v* tag yourself, or Run workflow on those
+# workflows. Do not also trigger on release: published (avoids double builds).
 
 on:
   pull_request:
@@ -169,3 +170,18 @@ jobs:
 
           echo "Dispatched Docker Publish for ${VERSION}"
           echo "- Docker Publish: dispatched (\`${VERSION}\`)." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Trigger Admin UI cPanel Deploy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+
+          gh workflow run admin-ui-cpanel-deploy.yml \
+            --repo "${{ github.repository }}" \
+            -f ref="${VERSION}"
+
+          echo "Dispatched Admin UI cPanel Deploy for ${VERSION}"
+          echo "- Admin UI cPanel Deploy: dispatched (\`${VERSION}\`)." >> "$GITHUB_STEP_SUMMARY"

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,3 +33,7 @@ A grouping construct for permissions in this product's RBAC model.
 **Hub runtime**:
 The deployable API package: published Docker Hub backend and worker images (including the Beat scheduler process), plus Postgres, Redis, and external SMTP. Does not include the admin UI.
 _Avoid_: Microservices (when meaning this package), full stack (when including the React frontend)
+
+**Admin UI host**:
+The deployable admin UI package: a static SPA build served from a static host (maintainer dogfood: cPanel at `rbac.mnfprofile.com`), calling the Hub runtime API cross-origin. Does not include the Hub runtime.
+_Avoid_: Hub runtime (when meaning the UI), frontend container (when meaning the static host path), full stack

--- a/docs/adr/0004-admin-ui-host-cpanel.md
+++ b/docs/adr/0004-admin-ui-host-cpanel.md
@@ -1,0 +1,3 @@
+# Admin UI host on cPanel via release-only static deploy
+
+We need a maintainer dogfood path and adopter runbook for the admin UI while keeping it **outside** the Hub runtime. The UI is a cross-origin static SPA at `rbac.mnfprofile.com` (cPanel Apache/LiteSpeed), built with `VITE_API_BASE_URL` pointing at `https://rbac-api.mnfprofile.com/api/v1`, deployed by a **separate** GitHub Actions workflow on `v*` tags plus `workflow_dispatch` (not on every `main` push), with distinctly named jobs for build, upload, and smoke. Vercel/Pages and the Hub `fastapi-rbac-frontend` nginx image remain secondary adopter options; Node-on-cPanel was rejected for dogfood because production Vite output is static files.

--- a/docs/deployment/QUICK_RELEASE_GUIDE.md
+++ b/docs/deployment/QUICK_RELEASE_GUIDE.md
@@ -132,7 +132,7 @@ After creating a release, verify:
   - `mnaimfaizy/fastapi-rbac-worker:vX.Y.Z`
 - [ ] `:latest` advanced for all three only after Promote latest (not during individual builds)
 - [ ] Images support both architectures (linux/amd64, linux/arm64)
-- [ ] GitHub Actions **Admin UI cPanel Deploy** completes: Build Admin UI Assets → Upload Admin UI to cPanel → Smoke Admin UI HTTPS (needs cPanel FTP secrets)
+- [ ] GitHub Actions **Admin UI cPanel Deploy** completes: Build Admin UI Assets → Upload Admin UI to cPanel → Smoke Admin UI HTTPS (needs `UI_FTP_*` secrets)
 - [ ] VERSION file updated to `X.Y.Z` (without 'v')
 - [ ] Release notes updated in `docs/release-notes.md` (release history SSOT)
 - [ ] Git tag created and pushed

--- a/docs/deployment/QUICK_RELEASE_GUIDE.md
+++ b/docs/deployment/QUICK_RELEASE_GUIDE.md
@@ -112,8 +112,8 @@ git branch -d hotfix/v1.2.4
 
 Docker Publish supports two triggers (both valid):
 
-- **Automatic after Release PR merge:** `release-tag-on-merge` creates the `v*` tag/Release, then dispatches Docker Publish (a tag push from `GITHUB_TOKEN` alone does not start other workflows).
-- **Manual:** push a `v*` tag yourself, or use **Actions → Docker Publish → Run workflow** with the version tag.
+- **Automatic after Release PR merge:** `release-tag-on-merge` creates the `v*` tag/Release, then dispatches **Docker Publish** and **Admin UI cPanel Deploy** (a tag push from `GITHUB_TOKEN` alone does not start other workflows).
+- **Manual:** push a `v*` tag yourself, or use **Actions → Docker Publish / Admin UI cPanel Deploy → Run workflow**.
 
 1. Go to GitHub Actions → Docker Publish workflow
 2. Click "Run workflow"
@@ -132,10 +132,12 @@ After creating a release, verify:
   - `mnaimfaizy/fastapi-rbac-worker:vX.Y.Z`
 - [ ] `:latest` advanced for all three only after Promote latest (not during individual builds)
 - [ ] Images support both architectures (linux/amd64, linux/arm64)
+- [ ] GitHub Actions **Admin UI cPanel Deploy** completes: Build Admin UI Assets → Upload Admin UI to cPanel → Smoke Admin UI HTTPS (needs cPanel FTP secrets)
 - [ ] VERSION file updated to `X.Y.Z` (without 'v')
 - [ ] Release notes updated in `docs/release-notes.md` (release history SSOT)
 - [ ] Git tag created and pushed
 - [ ] Docker Hub repo descriptions reflect `*.dockerhub.md` sources (updated after promote; soft-fail OK)
+- [ ] Admin UI host reachable at `https://rbac.mnfprofile.com` (when dogfood host is configured)
 
 ## 🐛 Quick Troubleshooting
 

--- a/docs/deployment/admin-ui/cpanel-setup.md
+++ b/docs/deployment/admin-ui/cpanel-setup.md
@@ -1,0 +1,110 @@
+# Admin UI host — cPanel setup
+
+**Created:** 2026-07-25
+**Last verified:** 2026-07-25
+
+First-time path to serve the Admin UI host on cPanel at `rbac.mnfprofile.com`, deployed by GitHub Actions on product releases.
+
+## Staleness checklist — re-verify if any apply
+
+- [ ] This document is older than **6 months** since **Last verified**
+- [ ] cPanel subdomain / FTP UI labels change
+- [ ] Release trigger or required GitHub secrets/variables change
+- [ ] Vite build env names or SPA rewrite needs change
+
+---
+
+## 1. Create the subdomain
+
+In cPanel → **Domains** / **Subdomains**:
+
+| Field | Value |
+| --- | --- |
+| Subdomain | `rbac` |
+| Domain | `mnfprofile.com` |
+| Document root | e.g. `rbac.mnfprofile.com` or `public_html/rbac` (note the path) |
+
+Ensure AutoSSL (or equivalent) issues HTTPS for `rbac.mnfprofile.com`.
+
+DNS: if the subdomain is not auto-created, add an `A` (or `CNAME`) record for `rbac` to your shared-hosting target.
+
+```bash
+nslookup rbac.mnfprofile.com
+```
+
+---
+
+## 2. GitHub configuration
+
+### Repository variables
+
+| Name | Example |
+| --- | --- |
+| `ADMIN_UI_VITE_API_BASE_URL` | `https://rbac-api.mnfprofile.com/api/v1` |
+| `ADMIN_UI_PUBLIC_URL` | `https://rbac.mnfprofile.com` |
+
+### Repository secrets
+
+Create an FTP (or FTPS) account in cPanel that can write to the subdomain document root.
+
+| Name | Purpose |
+| --- | --- |
+| `CPANEL_FTP_SERVER` | Host (often your domain or a host like `ftp.mnfprofile.com`) |
+| `CPANEL_FTP_USERNAME` | FTP username |
+| `CPANEL_FTP_PASSWORD` | FTP password |
+| `CPANEL_FTP_SERVER_DIR` | Remote directory for the docroot (e.g. `/rbac.mnfprofile.com/` — trailing slash recommended) |
+
+Do not commit these values.
+
+---
+
+## 3. Align Hub runtime env
+
+On the Oracle (or other) Hub runtime host, update `.env` as in [Admin UI host overview](./index.md), then:
+
+```bash
+cd ~/fastapi_rbac/docs/deployment/hub-runtime   # or your path
+docker compose --env-file .env -f compose.yml up -d api
+```
+
+---
+
+## 4. Deploy
+
+**Automatic after Release PR merge:** `release-tag-on-merge` dispatches this workflow with `ref=vX.Y.Z` (same reason Docker Publish is dispatched: `GITHUB_TOKEN` tag pushes do not start other workflows).
+
+**Also:** a human-pushed `v*` tag starts this workflow directly.
+
+**Manual:** Actions → **Admin UI cPanel Deploy** → **Run workflow** (optional `ref`).
+
+Jobs (separate names):
+
+1. `build-admin-ui-assets` — `npm ci` + production build + artifact
+2. `upload-admin-ui-cpanel` — FTP sync of `dist/`
+3. `smoke-admin-ui-https` — HTTPS check of `ADMIN_UI_PUBLIC_URL`
+
+---
+
+## 5. Smoke-test
+
+```bash
+curl -fsSI "https://rbac.mnfprofile.com/"
+# Log in against the live API; confirm no CORS errors in the browser
+# Trigger a password-reset email and confirm the link uses rbac.mnfprofile.com
+```
+
+Client-side routes (e.g. `/reset-password`) must not 404 on refresh — that is what `.htaccess` is for.
+
+---
+
+## Manual upload fallback
+
+If Actions secrets are not ready:
+
+```bash
+cd react-frontend
+export VITE_API_BASE_URL=https://rbac-api.mnfprofile.com/api/v1
+npm ci --legacy-peer-deps
+npm run build
+# Upload contents of dist/ into the subdomain document root (include .htaccess)
+```

--- a/docs/deployment/admin-ui/cpanel-setup.md
+++ b/docs/deployment/admin-ui/cpanel-setup.md
@@ -49,12 +49,12 @@ Create an FTP (or FTPS) account in cPanel that can write to the subdomain docume
 
 | Name | Purpose |
 | --- | --- |
-| `CPANEL_FTP_SERVER` | Host (often your domain or a host like `ftp.mnfprofile.com`) |
-| `CPANEL_FTP_USERNAME` | FTP username |
-| `CPANEL_FTP_PASSWORD` | FTP password |
-| `CPANEL_FTP_SERVER_DIR` | Remote directory for the docroot (e.g. `/rbac.mnfprofile.com/` — trailing slash recommended) |
+| `UI_FTP_SERVER` | Host (often your domain or a host like `ftp.mnfprofile.com`) |
+| `UI_FTP_USERNAME` | FTP username |
+| `UI_FTP_PASSWORD` | FTP password |
+| `UI_FTP_SERVER_DIR` | Remote directory for the docroot (e.g. `/rbac.mnfprofile.com/` — trailing slash recommended) |
 
-Do not commit these values.
+These are separate from the MkDocs deploy secrets (`FTP_SERVER`, `FTP_USERNAME`, `FTP_PASSWORD`, …). Do not commit these values.
 
 ---
 

--- a/docs/deployment/admin-ui/index.md
+++ b/docs/deployment/admin-ui/index.md
@@ -1,0 +1,54 @@
+# Admin UI host
+
+Deploy the **admin UI** as a static SPA on a static host. This package is **not** part of the [Hub runtime](../hub-runtime/index.md).
+
+| Piece | Maintainer dogfood |
+| --- | --- |
+| Host | cPanel shared hosting (Apache / LiteSpeed) |
+| Public UI | `https://rbac.mnfprofile.com` |
+| API (cross-origin) | `https://rbac-api.mnfprofile.com` |
+| Build | GitHub Actions on `v*` release tags + manual `workflow_dispatch` |
+| Serve | Static `dist/` + SPA `.htaccess` (not Node.js on cPanel) |
+
+## Contents
+
+| Artifact | Purpose |
+| --- | --- |
+| [cPanel setup](./cpanel-setup.md) | Subdomain, docroot, secrets, first deploy |
+| [`.github/workflows/admin-ui-cpanel-deploy.yml`](../../../.github/workflows/admin-ui-cpanel-deploy.yml) | Named jobs: build → upload → smoke |
+| `react-frontend/public/.htaccess` | Copied into `dist/` for SPA route fallback |
+
+## Quick mental model
+
+```text
+Browser  →  https://rbac.mnfprofile.com     (Admin UI host, static)
+         →  https://rbac-api.mnfprofile.com  (Hub runtime API, CORS + cookies)
+```
+
+Build-time env (dogfood):
+
+```bash
+VITE_API_BASE_URL=https://rbac-api.mnfprofile.com/api/v1
+```
+
+On the Hub runtime host, set at least:
+
+```bash
+FRONTEND_URL=https://rbac.mnfprofile.com
+EMAIL_VERIFICATION_URL=https://rbac.mnfprofile.com/verify-email
+PASSWORD_RESET_URL=https://rbac.mnfprofile.com/reset-password
+BACKEND_CORS_ORIGINS=["https://rbac.mnfprofile.com"]
+```
+
+Then recreate/restart the API container so CORS and email links pick up the new values.
+
+## Adopter options (secondary)
+
+1. **Any static host** (Vercel, Cloudflare Pages, Netlify, other cPanel): same build env + CORS/FRONTEND_URL on your API.
+2. **Hub image** `mnaimfaizy/fastapi-rbac-frontend`: nginx container with same-origin `/api` proxy — use when you want UI next to the API in Compose/k8s, not the default Admin UI host path.
+
+## Related
+
+- ADR: [0004 — Admin UI host on cPanel](../../adr/0004-admin-ui-host-cpanel.md)
+- Hub runtime: [index](../hub-runtime/index.md) · [env.example](../hub-runtime/env.example)
+- React deployment notes: [frontend/react/deployment.md](../../frontend/react/deployment.md)

--- a/docs/deployment/hub-runtime/env.example
+++ b/docs/deployment/hub-runtime/env.example
@@ -53,15 +53,17 @@ CELERY_RESULT_BACKEND=redis://redis:6379/0
 FIRST_SUPERUSER_EMAIL=admin@example.com
 FIRST_SUPERUSER_PASSWORD=
 
-# CORS — API-only validation; add frontend origins when you bring the UI back
-BACKEND_CORS_ORIGINS=["https://rbac-api.mnfprofile.com"]
+# CORS — Admin UI host origin (cross-origin). API docs origin optional.
+BACKEND_CORS_ORIGINS=["https://rbac.mnfprofile.com"]
 
 # Email — required for full-flow validation (password reset, etc.)
+# Links must point at the Admin UI host, not the API hostname.
 EMAILS_ENABLED=true
 EMAILS_FROM_EMAIL=no-reply@your-domain.com
 EMAILS_FROM_NAME=FastAPI RBAC
-EMAIL_VERIFICATION_URL=https://rbac-api.mnfprofile.com/verify-email
-FRONTEND_URL=https://rbac-api.mnfprofile.com
+FRONTEND_URL=https://rbac.mnfprofile.com
+EMAIL_VERIFICATION_URL=https://rbac.mnfprofile.com/verify-email
+PASSWORD_RESET_URL=https://rbac.mnfprofile.com/reset-password
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587
 SMTP_TLS=true

--- a/docs/deployment/hub-runtime/index.md
+++ b/docs/deployment/hub-runtime/index.md
@@ -7,7 +7,7 @@ Deploy the published Docker Hub **API package** (not the admin UI):
 
 plus Postgres, Redis, and external SMTP, behind Caddy HTTPS.
 
-This is the same topology for staging and production-style validation. Frontend hosting is out of scope here.
+This is the same topology for staging and production-style validation. Admin UI hosting is out of scope here — see [Admin UI host](../admin-ui/index.md).
 
 ## Contents
 
@@ -35,6 +35,7 @@ chmod +x bootstrap.sh
 
 ## Related
 
+- Admin UI host: [index](../admin-ui/index.md) · [cPanel setup](../admin-ui/cpanel-setup.md)
 - Research: [Hosting Docker Hub images](../../internal/research/hosting-docker-hub-images.md)
 - ADR: [0003 — Hub runtime on Oracle Always Free](../../adr/0003-hub-runtime-oracle-compose.md)
 - Issue: [#96](https://github.com/mnaimfaizy/fastapi_rbac/issues/96)

--- a/docs/deployment/hub-runtime/oracle-always-free-setup.md
+++ b/docs/deployment/hub-runtime/oracle-always-free-setup.md
@@ -373,6 +373,9 @@ cp env.example .env
 #   DOMAIN=rbac-api.mnfprofile.com
 #   FIRST_SUPERUSER_EMAIL=...
 #   SMTP_HOST / SMTP_PORT / SMTP_USER / SMTP_PASSWORD / EMAILS_FROM_EMAIL
+# Admin UI host (when rbac.mnfprofile.com is live — see env.example):
+#   FRONTEND_URL / EMAIL_VERIFICATION_URL / PASSWORD_RESET_URL
+#   BACKEND_CORS_ORIGINS=["https://rbac.mnfprofile.com"]
 nano .env   # or vim
 
 chmod +x bootstrap.sh
@@ -382,6 +385,8 @@ chmod +x bootstrap.sh
 `bootstrap.sh` fills empty `SECRET_KEY` / DB / Redis / superuser password fields, pulls Hub images, starts Compose, and waits for API health.
 
 The API container entrypoint runs migrations and initial data (including the first superuser).
+
+When the [Admin UI host](../admin-ui/index.md) is deployed, keep those CORS / `FRONTEND_URL` / email link values on the UI origin and recreate the API container after editing `.env`.
 
 ---
 
@@ -398,6 +403,8 @@ Exercise login, a password-reset email (SMTP), and confirm worker/beat stay up:
 docker compose --env-file .env -f compose.yml ps
 docker compose --env-file .env -f compose.yml logs -f worker beat
 ```
+
+With the Admin UI host live, also open `https://rbac.mnfprofile.com`, confirm login (no CORS errors), and that reset/verify email links use that host.
 
 ---
 

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -4,4 +4,6 @@ This section covers how to deploy the application to production.
 
 - **[Hub runtime](./hub-runtime/index.md):** Pull published Docker Hub API images (backend + worker/beat) with Postgres, Redis, Caddy, and external SMTP. Start here for production-shaped validation.
 - **[Oracle Always Free setup](./hub-runtime/oracle-always-free-setup.md):** First-time free OCI environment for the Hub runtime (dated; re-verify when stale).
+- **[Admin UI host](./admin-ui/index.md):** Static admin UI on cPanel (`rbac.mnfprofile.com`), release-only GitHub Actions deploy, cross-origin to the Hub runtime API.
+- **[cPanel Admin UI setup](./admin-ui/cpanel-setup.md):** First-time subdomain, FTP secrets, and smoke checks (dated; re-verify when stale).
 - **[Production Deployment](./production-deployment-guide.md):** A step-by-step guide for deploying the application.

--- a/docs/frontend/react/deployment.md
+++ b/docs/frontend/react/deployment.md
@@ -2,7 +2,9 @@
 
 Build and run the React SPA for Docker and production.
 
-Related: [Setup](./setup.md), [Deployment overview](../../deployment/index.md), [Production setup](../../deployment/PRODUCTION_SETUP.md).
+Related: [Setup](./setup.md), [Deployment overview](../../deployment/index.md), [Admin UI host (cPanel)](../../deployment/admin-ui/index.md), [Production setup](../../deployment/PRODUCTION_SETUP.md).
+
+For maintainer dogfood and the adopter static-host path, prefer **[Admin UI host](../../deployment/admin-ui/index.md)** over running the Hub frontend container.
 
 ## Production build
 

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -42,6 +42,10 @@ Go to: [`../deployment/PRODUCTION_SETUP.md`](../deployment/PRODUCTION_SETUP.md)
 
 Go to: [`../deployment/hub-runtime/index.md`](../deployment/hub-runtime/index.md) and [Oracle Always Free setup](../deployment/hub-runtime/oracle-always-free-setup.md)
 
+### 🖥️ I want to host the admin UI (cPanel / static)
+
+Go to: [`../deployment/admin-ui/index.md`](../deployment/admin-ui/index.md) and [cPanel setup](../deployment/admin-ui/cpanel-setup.md)
+
 ### ❓ I'm having issues
 
 Browse: [`../troubleshooting/`](../troubleshooting/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,9 @@ nav:
       - "Hub runtime":
           - "Overview": "deployment/hub-runtime/index.md"
           - "Oracle Always Free setup": "deployment/hub-runtime/oracle-always-free-setup.md"
+      - "Admin UI host":
+          - "Overview": "deployment/admin-ui/index.md"
+          - "cPanel setup": "deployment/admin-ui/cpanel-setup.md"
       - "Production Deployment": "deployment/production-deployment-guide.md"
       - "Quick Release Guide": "deployment/QUICK_RELEASE_GUIDE.md"
       - "Release Process": "deployment/RELEASE_PROCESS.md"

--- a/react-frontend/public/.htaccess
+++ b/react-frontend/public/.htaccess
@@ -1,0 +1,9 @@
+# SPA fallback for Apache / LiteSpeed (cPanel Admin UI host)
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteBase /
+  RewriteRule ^index\.html$ - [L]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteRule . /index.html [L]
+</IfModule>


### PR DESCRIPTION
## Summary
- Add **Admin UI host** package: static SPA on cPanel at `rbac.mnfprofile.com`, cross-origin to Hub runtime API
- Add release-only GitHub Actions workflow with separate jobs (build → FTP upload → HTTPS smoke), dispatched from release-tag-on-merge
- Document runbook/ADR/glossary; align Hub `env.example` CORS and email URLs to the UI origin

## Test plan
- [x] Create cPanel subdomain `rbac` and configure GitHub FTP secrets/vars per `docs/deployment/admin-ui/cpanel-setup.md`
- [ ] Run **Admin UI cPanel Deploy** via `workflow_dispatch` and confirm `https://rbac.mnfprofile.com` serves the SPA
- [x] Update Oracle Hub `.env` CORS/`FRONTEND_URL`/email URLs; recreate `api`; verify login without CORS errors
- [x] Confirm password-reset / verify-email links point at `rbac.mnfprofile.com`
- [ ] Confirm a Release PR merge dispatches both Docker Publish and Admin UI cPanel Deploy