### PR TITLE
fix(ui): harden LiteSpeed SPA .htaccess for hard refresh

### DIFF
--- a/.github/workflows/admin-ui-cpanel-deploy.yml
+++ b/.github/workflows/admin-ui-cpanel-deploy.yml
@@ -51,9 +51,12 @@ jobs:
       - name: Ensure SPA .htaccess in dist
         working-directory: react-frontend
         run: |
-          if [ ! -f dist/.htaccess ]; then
-            cp public/.htaccess dist/.htaccess
-          fi
+          set -euo pipefail
+          # Always overwrite so LiteSpeed rules stay in sync with the repo.
+          cp -f public/.htaccess dist/.htaccess
+          test -f dist/.htaccess
+          echo "dist/.htaccess present ($(wc -c < dist/.htaccess) bytes)"
+          ls -la dist/.htaccess dist/index.html
 
       - name: Upload dist artifact
         uses: actions/upload-artifact@v4
@@ -61,6 +64,8 @@ jobs:
           name: admin-ui-dist
           path: react-frontend/dist/
           retention-days: 7
+          # Dotfiles (.htaccess) must ship for SPA fallback on cPanel/LiteSpeed.
+          include-hidden-files: true
 
   upload-admin-ui-cpanel:
     name: Upload Admin UI to cPanel
@@ -97,4 +102,21 @@ jobs:
           echo "Checking ${ADMIN_UI_PUBLIC_URL}/"
           curl -fsSI --max-time 30 "${ADMIN_UI_PUBLIC_URL}/" | head -n 20
           curl -fsS --max-time 30 "${ADMIN_UI_PUBLIC_URL}/" -o /dev/null
-          echo "Admin UI host smoke OK"
+
+          # Hard-refresh / deep-link path must return the SPA shell, not LiteSpeed 404 HTML.
+          ROUTE="${ADMIN_UI_PUBLIC_URL%/}/login"
+          echo "Checking SPA fallback: ${ROUTE}"
+          BODY="$(mktemp)"
+          CODE="$(curl -sS --max-time 30 -o "${BODY}" -w "%{http_code}" "${ROUTE}")"
+          # Rewrite → 200; ErrorDocument 404 /index.html → 404 with SPA body (still usable).
+          if [[ "${CODE}" != "200" && "${CODE}" != "404" ]]; then
+            echo "::error::Unexpected HTTP ${CODE} for ${ROUTE}"
+            head -c 500 "${BODY}" || true
+            exit 1
+          fi
+          if ! grep -qE 'id="root"|/assets/index-' "${BODY}"; then
+            echo "::error::SPA shell not found at ${ROUTE} (LiteSpeed/host 404 page? HTTP ${CODE})"
+            head -c 800 "${BODY}" || true
+            exit 1
+          fi
+          echo "Admin UI host smoke OK (root + /login SPA shell, HTTP ${CODE})"

--- a/docs/deployment/admin-ui/cpanel-setup.md
+++ b/docs/deployment/admin-ui/cpanel-setup.md
@@ -1,7 +1,7 @@
 # Admin UI host — cPanel setup
 
 **Created:** 2026-07-25
-**Last verified:** 2026-07-25
+**Last verified:** 2026-07-26
 
 First-time path to serve the Admin UI host on cPanel at `rbac.mnfprofile.com`, deployed by GitHub Actions on product releases.
 
@@ -93,7 +93,9 @@ curl -fsSI "https://rbac.mnfprofile.com/"
 # Trigger a password-reset email and confirm the link uses rbac.mnfprofile.com
 ```
 
-Client-side routes (e.g. `/reset-password`) must not 404 on refresh — that is what `.htaccess` is for.
+Client-side routes (e.g. `/login`, `/reset-password`) must not show the host/LiteSpeed 404 page on refresh — that is what `react-frontend/public/.htaccess` is for (rewrite to `index.html`, `ErrorDocument 404`, LiteSpeed `CacheDisable`).
+
+If a deep link still shows a **cached** LiteSpeed 404 after deploy: in cPanel → **LiteSpeed Web Cache Manager** (or Cache), purge that subdomain, then hard-refresh. Confirm `.htaccess` exists in the subdomain document root (FTP must upload dotfiles).
 
 ---
 

--- a/react-frontend/public/.htaccess
+++ b/react-frontend/public/.htaccess
@@ -1,9 +1,32 @@
-# SPA fallback for Apache / LiteSpeed (cPanel Admin UI host)
+# SPA fallback for Apache / LiteSpeed (cPanel Admin UI host).
+# Without this, hard refresh / deep links (e.g. /login) hit a real 404;
+# LiteSpeed Cache can then keep serving that cached 404 page.
+
+DirectoryIndex index.html
+
+# Content negotiation can map /login to a non-existent login.* and 404.
+<IfModule mod_negotiation.c>
+  Options -MultiViews
+</IfModule>
+
 <IfModule mod_rewrite.c>
   RewriteEngine On
   RewriteBase /
+
+  # Serve real files (hashed /assets/*) and directories as-is.
   RewriteRule ^index\.html$ - [L]
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteCond %{REQUEST_FILENAME} !-d
-  RewriteRule . /index.html [L]
+  RewriteCond %{REQUEST_FILENAME} !-l
+  # Relative target is more reliable on LiteSpeed than an absolute /index.html.
+  RewriteRule . index.html [L]
+</IfModule>
+
+# Backup when rewrite is disabled: still return the SPA shell.
+ErrorDocument 404 /index.html
+
+# Do not let LiteSpeed Cache store HTML/404 responses for client routes.
+# Hashed assets under /assets/ remain fine to cache by URL uniqueness.
+<IfModule LiteSpeed>
+  CacheDisable public /
 </IfModule>


### PR DESCRIPTION
## Summary
- Harden `react-frontend/public/.htaccess` for cPanel/LiteSpeed: `-MultiViews`, relative `index.html` rewrite, `ErrorDocument 404`, `CacheDisable`.
- Always copy `.htaccess` into the deploy artifact (including hidden files) and smoke-test `/login` for the SPA shell.

## Test plan
- [x] Merge and run **Admin UI cPanel Deploy** (workflow_dispatch)
- [x] Hard-refresh `https://rbac.mnfprofile.com/login` — SPA loads, not LiteSpeed 404
- [x] If a cached 404 remains, purge LiteSpeed cache for the subdomain once
