### PR TITLE
fix(worker): register Celery tasks from app.worker

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -17,6 +17,10 @@ celery_config = get_cached_celery_config()
 # Update the Celery configuration
 celery_app.conf.update(celery_config)
 
+# Eagerly import task modules so `celery -A app.celery_app` registers them even
+# when conf.imports is not applied yet (e.g. inspect / early worker boot).
+from app import worker as _worker_tasks  # noqa: E402, F401
+
 # Conditional configuration for development mode
 if settings.MODE == ModeEnum.development:
     # Print debug information when running in development mode

--- a/backend/app/core/celery_config.py
+++ b/backend/app/core/celery_config.py
@@ -34,6 +34,10 @@ def get_celery_config() -> Dict[str, Any]:
         # Broker and Backend
         "broker_url": settings.CELERY_BROKER_URL,
         "result_backend": settings.CELERY_RESULT_BACKEND,
+        # Task modules must be imported by the worker process. The API registers
+        # them via background_tasks → app.worker; celery -A app.celery_app alone
+        # does not load that module, which leaves [tasks] empty and discards work.
+        "imports": ("app.worker",),
         # Serialization
         "task_serializer": settings.CELERY_TASK_SERIALIZER,
         "result_serializer": settings.CELERY_RESULT_SERIALIZER,

--- a/backend/scripts/docker/start-worker.sh
+++ b/backend/scripts/docker/start-worker.sh
@@ -8,4 +8,5 @@ export PYTHONPATH="/app"
 python ./app/backend_pre_start.py
 
 echo "Starting Celery worker..."
-exec celery -A app.celery_app worker --loglevel=info -Q emails,maintenance,logging,user_management,default,periodic_tasks --concurrency=2
+# Load app.worker so @celery_app.task handlers are registered (not just the app).
+exec celery -A app.worker:celery_app worker --loglevel=info -Q emails,maintenance,logging,user_management,default,periodic_tasks --concurrency=2

--- a/backend/scripts/local/start-worker.sh
+++ b/backend/scripts/local/start-worker.sh
@@ -33,7 +33,7 @@ PYTHONPATH=$PYTHONPATH python -c "import sys; print('Python path:', sys.path)"
 python ./app/backend_pre_start.py
 
 echo "Starting Celery worker..."
-celery -A app.celery_app worker --loglevel=info -Q emails,maintenance,logging,user_management,default,periodic_tasks --concurrency=2
+celery -A app.worker:celery_app worker --loglevel=info -Q emails,maintenance,logging,user_management,default,periodic_tasks --concurrency=2
 
 # If you want to run Celery beat (scheduler) in the same container
 # Start with:

--- a/backend/test/unit/test_celery_app_tasks.py
+++ b/backend/test/unit/test_celery_app_tasks.py
@@ -1,0 +1,18 @@
+"""Ensure Celery workers register task modules from app.worker."""
+
+from app.celery_app import celery_app
+
+
+def test_celery_app_imports_worker_tasks() -> None:
+    """Worker boot via app.celery_app must register security/email tasks."""
+    registered = set(celery_app.tasks.keys())
+    assert "app.worker.log_security_event_task" in registered
+    assert "app.worker.send_email_task" in registered
+    assert "app.worker.cleanup_tokens_task" in registered
+    assert "app.worker.process_account_lockout_task" in registered
+
+
+def test_celery_config_lists_worker_imports() -> None:
+    """conf.imports keeps task registration for celery -A app.celery_app."""
+    imports = tuple(celery_app.conf.imports or ())
+    assert "app.worker" in imports

--- a/docs/deployment/hub-runtime/split-managed-data.md
+++ b/docs/deployment/hub-runtime/split-managed-data.md
@@ -85,6 +85,8 @@ CELERY_RESULT_BACKEND=rediss://default:YOUR_UPSTASH_TOKEN@prompt-hippo-xxxxx.ups
 
 If `REDIS_HOST` includes `rediss://…@…:6379`, the app appends `:6379` again and Redis wait fails with `idna` / `label empty or too long`.
 
+Worker logs with an empty `[tasks]` list and `Received unregistered task of type 'app.worker…'` mean the process loaded `app.celery_app` without importing `app.worker`. Use `compose.worker.yml` as shipped (`celery -A app.worker:celery_app`) or a worker image that registers `imports=("app.worker",)`.
+
 3. **CA bundle:** production images require `/app/certs/ca.crt`. Split Compose mounts the host trust store (`/etc/ssl/certs/ca-certificates.crt`) there for Upstash public CAs. On the VM:
 
 ```bash

--- a/docs/deployment/hub-runtime/split/compose.worker.yml
+++ b/docs/deployment/hub-runtime/split/compose.worker.yml
@@ -24,7 +24,7 @@ services:
       [
         "/bin/bash",
         "-c",
-        "export PYTHONPATH=/app && python ./app/backend_pre_start.py && exec celery -A app.celery_app worker --loglevel=info -Q emails,maintenance,logging,user_management,default,periodic_tasks --concurrency=1",
+        "export PYTHONPATH=/app && python ./app/backend_pre_start.py && exec celery -A app.worker:celery_app worker --loglevel=info -Q emails,maintenance,logging,user_management,default,periodic_tasks --concurrency=1",
       ]
     networks:
       - hub_worker


### PR DESCRIPTION
## Summary
- Register `app.worker` tasks when loading `app.celery_app` (`imports` + eager import).
- Point worker entrypoints / split `compose.worker.yml` at `celery -A app.worker:celery_app` so current Hub worker images also load tasks.
- Unit test covers registered task names; document the empty `[tasks]` failure mode.

## Test plan
- [ ] Worker logs show non-empty `[tasks]` including `app.worker.log_security_event_task`
- [ ] Login no longer produces `Received unregistered task` on the worker
- [ ] Interim on VM: edit compose command to `-A app.worker:celery_app` and recreate worker (works on `v0.1.1-beta` without a new image)
