### PR TITLE
feat(deploy): add Hub bootstrap CLI subcommands

### DIFF
--- a/docs/deployment/hub-runtime/_bootstrap_cli.sh
+++ b/docs/deployment/hub-runtime/_bootstrap_cli.sh
@@ -1,0 +1,425 @@
+# Shared Hub runtime bootstrap CLI (sourced, not executed).
+# Callers must set before hub_bootstrap_main:
+#   ROOT_DIR, ENV_FILE, EXAMPLE_FILE, COMPOSE_FILE
+#   HUB_ROLE (onebox|api|worker), HUB_SERVICES (space-separated)
+#   SCRIPT_NAME (basename for usage)
+#   prepare_env() — role-specific .env / validation
+# shellcheck shell=bash
+
+HUB_NO_PULL=0
+HUB_NO_WAIT=0
+
+dc() {
+  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" "$@"
+}
+
+hub_usage() {
+  cat <<EOF
+Usage: ${SCRIPT_NAME} [global flags] <command> [args]
+
+Hub runtime bootstrap (${HUB_ROLE}). Default command with no args: up
+
+Commands:
+  help, -h, --help          Show this help
+  up [SERVICE…]             Prepare .env, pull (unless --no-pull), start stack
+  down [SERVICE…]           Stop/remove stack (all → compose down; named → stop)
+  restart [SERVICE…]        Restart all or named services
+  pull [SERVICE…]           Pull images
+  status, ps                Show compose status
+  logs [-f] [-n N] [SVC…]   Show logs (--follow / --tail)
+  health                    Wait for API health (onebox/api) or show worker ps
+  env, prepare              Only ensure/fill .env (no containers)
+  config                    Validate compose file (docker compose config)
+  exec SERVICE CMD…         Run a command in a running service
+
+Global flags:
+  --env-file PATH           Env file (default: .env or \$ENV_FILE)
+  --no-pull                 Skip image pull on up
+  --no-wait                 Skip health wait on up / health
+  -h, --help                Show this help
+
+Services for this role: ${HUB_SERVICES}
+
+Examples:
+  ${SCRIPT_NAME}
+  ${SCRIPT_NAME} up
+  ${SCRIPT_NAME} up api
+  ${SCRIPT_NAME} status
+  ${SCRIPT_NAME} logs -f worker
+  ${SCRIPT_NAME} health
+  ${SCRIPT_NAME} restart worker
+  ${SCRIPT_NAME} env
+EOF
+}
+
+hub_require_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is required. See oracle-always-free-setup.md / split-managed-data.md." >&2
+    exit 1
+  fi
+}
+
+hub_is_valid_service() {
+  local svc="$1"
+  local s
+  for s in ${HUB_SERVICES}; do
+    if [[ "$s" == "$svc" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+hub_validate_services() {
+  local svc
+  for svc in "$@"; do
+    if ! hub_is_valid_service "$svc"; then
+      echo "Unknown service '${svc}' for role ${HUB_ROLE}." >&2
+      echo "Valid: ${HUB_SERVICES}" >&2
+      exit 1
+    fi
+  done
+}
+
+hub_domain() {
+  local domain
+  domain="$(grep -E '^DOMAIN=' "$ENV_FILE" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'")"
+  echo "${domain:-rbac-api.mnfprofile.com}"
+}
+
+hub_wait_api_health() {
+  local domain
+  domain="$(hub_domain)"
+  echo "Waiting for API health..."
+  local _
+  for _ in $(seq 1 60); do
+    if curl -fsS "https://${domain}/api/v1/health" >/dev/null 2>&1 || \
+       dc exec -T api curl -fsS "http://localhost:8000/api/v1/health" >/dev/null 2>&1; then
+      echo "API is up."
+      echo "API: https://${domain}/api/v1/health"
+      echo "OpenAPI: https://${domain}/docs"
+      if [[ -f "$ENV_FILE" ]]; then
+        echo "Superuser email is FIRST_SUPERUSER_EMAIL in ${ENV_FILE}"
+      fi
+      return 0
+    fi
+    sleep 5
+  done
+  echo "Timed out waiting for healthy API. Check: ${SCRIPT_NAME} logs" >&2
+  return 1
+}
+
+cmd_up() {
+  local services=("$@")
+  prepare_env
+  hub_require_docker
+  if [[ "${HUB_NO_PULL}" -eq 0 ]]; then
+    echo "Pulling images (IMAGE_TAG from ${ENV_FILE})..."
+    if [[ ${#services[@]} -gt 0 ]]; then
+      dc pull "${services[@]}"
+    else
+      dc pull
+    fi
+  else
+    echo "Skipping pull (--no-pull)."
+  fi
+
+  echo "Starting Hub runtime (${HUB_ROLE})..."
+  if [[ ${#services[@]} -gt 0 ]]; then
+    dc up -d "${services[@]}"
+  else
+    dc up -d
+  fi
+
+  if [[ "${HUB_ROLE}" == "worker" ]]; then
+    echo "Worker stack status:"
+    dc ps
+    echo "Worker + Beat are up (or starting)."
+    echo "Stop this OCI instance when you finish testing to save Always Free idle risk and Upstash commands."
+    echo "Logs: ${SCRIPT_NAME} logs -f worker beat"
+    return 0
+  fi
+
+  # Health wait when API (or full stack) is in scope
+  local need_wait=0
+  if [[ ${#services[@]} -eq 0 ]]; then
+    need_wait=1
+  else
+    local s
+    for s in "${services[@]}"; do
+      if [[ "$s" == "api" || "$s" == "caddy" ]]; then
+        need_wait=1
+        break
+      fi
+    done
+  fi
+
+  if [[ "${HUB_NO_WAIT}" -eq 1 ]]; then
+    echo "Skipping health wait (--no-wait)."
+    dc ps
+    return 0
+  fi
+
+  if [[ "${need_wait}" -eq 1 ]]; then
+    hub_wait_api_health || exit 1
+    if [[ "${HUB_ROLE}" == "api" ]]; then
+      echo "Start the worker VM separately: ./bootstrap-worker.sh"
+    fi
+  else
+    dc ps
+  fi
+}
+
+cmd_down() {
+  local services=("$@")
+  hub_require_docker
+  if [[ ${#services[@]} -eq 0 ]]; then
+    echo "Stopping and removing Hub runtime (${HUB_ROLE})..."
+    dc down
+  else
+    echo "Stopping: ${services[*]}"
+    dc stop "${services[@]}"
+  fi
+}
+
+cmd_restart() {
+  local services=("$@")
+  hub_require_docker
+  if [[ ${#services[@]} -eq 0 ]]; then
+    dc restart
+  else
+    dc restart "${services[@]}"
+  fi
+}
+
+cmd_pull() {
+  local services=("$@")
+  prepare_env
+  hub_require_docker
+  if [[ ${#services[@]} -gt 0 ]]; then
+    dc pull "${services[@]}"
+  else
+    dc pull
+  fi
+}
+
+cmd_status() {
+  hub_require_docker
+  if [[ ! -f "$ENV_FILE" ]]; then
+    echo "Missing ${ENV_FILE}. Run: ${SCRIPT_NAME} env" >&2
+    exit 1
+  fi
+  dc ps
+}
+
+cmd_logs() {
+  hub_require_docker
+  if [[ ! -f "$ENV_FILE" ]]; then
+    echo "Missing ${ENV_FILE}. Run: ${SCRIPT_NAME} env" >&2
+    exit 1
+  fi
+  local follow=0
+  local tail_n=""
+  local services=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -f | --follow)
+        follow=1
+        shift
+        ;;
+      -n | --tail)
+        if [[ $# -lt 2 ]]; then
+          echo "--tail requires a number" >&2
+          exit 1
+        fi
+        tail_n="$2"
+        shift 2
+        ;;
+      --tail=*)
+        tail_n="${1#--tail=}"
+        shift
+        ;;
+      -*)
+        echo "Unknown logs flag: $1" >&2
+        exit 1
+        ;;
+      *)
+        services+=("$1")
+        shift
+        ;;
+    esac
+  done
+  if [[ ${#services[@]} -gt 0 ]]; then
+    hub_validate_services "${services[@]}"
+  fi
+  local args=()
+  if [[ "${follow}" -eq 1 ]]; then
+    args+=(-f)
+  fi
+  if [[ -n "${tail_n}" ]]; then
+    args+=(--tail "${tail_n}")
+  fi
+  if [[ ${#services[@]} -gt 0 ]]; then
+    dc logs "${args[@]}" "${services[@]}"
+  else
+    dc logs "${args[@]}"
+  fi
+}
+
+cmd_health() {
+  hub_require_docker
+  if [[ ! -f "$ENV_FILE" ]]; then
+    echo "Missing ${ENV_FILE}. Run: ${SCRIPT_NAME} env" >&2
+    exit 1
+  fi
+  if [[ "${HUB_ROLE}" == "worker" ]]; then
+    echo "Worker role has no HTTP health endpoint. Stack status:"
+    dc ps
+    echo "Tip: ${SCRIPT_NAME} logs -f worker"
+    return 0
+  fi
+  if [[ "${HUB_NO_WAIT}" -eq 1 ]]; then
+    local domain
+    domain="$(hub_domain)"
+    if curl -fsS "https://${domain}/api/v1/health" >/dev/null 2>&1 || \
+       dc exec -T api curl -fsS "http://localhost:8000/api/v1/health" >/dev/null 2>&1; then
+      echo "API health OK: https://${domain}/api/v1/health"
+      return 0
+    fi
+    echo "API health check failed." >&2
+    exit 1
+  fi
+  hub_wait_api_health || exit 1
+}
+
+cmd_env() {
+  prepare_env
+  echo "Env ready: ${ENV_FILE}"
+}
+
+cmd_config() {
+  prepare_env
+  hub_require_docker
+  dc config
+}
+
+cmd_exec() {
+  hub_require_docker
+  if [[ $# -lt 2 ]]; then
+    echo "Usage: ${SCRIPT_NAME} exec SERVICE CMD…" >&2
+    exit 1
+  fi
+  local svc="$1"
+  shift
+  hub_validate_services "$svc"
+  dc exec -T "$svc" "$@"
+}
+
+hub_bootstrap_main() {
+  local cmd=""
+  local positional=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h | --help)
+        hub_usage
+        return 0
+        ;;
+      help)
+        if [[ -z "$cmd" ]]; then
+          hub_usage
+          return 0
+        fi
+        positional+=("$1")
+        shift
+        ;;
+      --env-file)
+        if [[ $# -lt 2 ]]; then
+          echo "--env-file requires a path" >&2
+          exit 1
+        fi
+        ENV_FILE="$2"
+        shift 2
+        ;;
+      --env-file=*)
+        ENV_FILE="${1#--env-file=}"
+        shift
+        ;;
+      --no-pull)
+        HUB_NO_PULL=1
+        shift
+        ;;
+      --no-wait)
+        HUB_NO_WAIT=1
+        shift
+        ;;
+      up | down | restart | pull | status | ps | logs | health | env | prepare | config | exec)
+        if [[ -n "$cmd" ]]; then
+          positional+=("$1")
+          shift
+        else
+          cmd="$1"
+          shift
+        fi
+        ;;
+      -*)
+        # Subcommand-specific flags (e.g. logs -f) once a command is known
+        if [[ -n "$cmd" ]]; then
+          positional+=("$1")
+          shift
+        else
+          echo "Unknown flag: $1 (try --help)" >&2
+          exit 1
+        fi
+        ;;
+      *)
+        if [[ -z "$cmd" ]]; then
+          # Bare service name without command → treat as up SERVICE
+          cmd="up"
+          positional+=("$1")
+          shift
+        else
+          positional+=("$1")
+          shift
+        fi
+        ;;
+    esac
+  done
+
+  if [[ -z "$cmd" ]]; then
+    cmd="up"
+  fi
+
+  # Normalize aliases
+  case "$cmd" in
+    ps) cmd="status" ;;
+    prepare) cmd="env" ;;
+  esac
+
+  # Validate service args for commands that take services (not logs/exec — handled inside)
+  case "$cmd" in
+    up | down | restart | pull)
+      if [[ ${#positional[@]} -gt 0 ]]; then
+        hub_validate_services "${positional[@]}"
+      fi
+      ;;
+  esac
+
+  case "$cmd" in
+    up) cmd_up "${positional[@]}" ;;
+    down) cmd_down "${positional[@]}" ;;
+    restart) cmd_restart "${positional[@]}" ;;
+    pull) cmd_pull "${positional[@]}" ;;
+    status) cmd_status ;;
+    logs) cmd_logs "${positional[@]}" ;;
+    health) cmd_health ;;
+    env) cmd_env ;;
+    config) cmd_config ;;
+    exec) cmd_exec "${positional[@]}" ;;
+    *)
+      echo "Unknown command: ${cmd}" >&2
+      hub_usage >&2
+      exit 1
+      ;;
+  esac
+}

--- a/docs/deployment/hub-runtime/bootstrap.sh
+++ b/docs/deployment/hub-runtime/bootstrap.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Hub runtime bootstrap: ensure .env secrets, then pull and start the package.
+# Hub runtime bootstrap (one-box Compose): secrets, pull, start, health.
+# Usage: ./bootstrap.sh [--help] [command] [args…]
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -7,9 +8,15 @@ cd "$ROOT_DIR"
 
 ENV_FILE="${ENV_FILE:-.env}"
 EXAMPLE_FILE="env.example"
+COMPOSE_FILE="compose.yml"
+HUB_ROLE="onebox"
+HUB_SERVICES="caddy api worker beat db redis"
+SCRIPT_NAME="$(basename "$0")"
+
+# shellcheck source=_bootstrap_cli.sh
+source "${ROOT_DIR}/_bootstrap_cli.sh"
 
 gen_secret() {
-  # URL-safe for Redis/Celery URLs and env files
   if command -v openssl >/dev/null 2>&1; then
     openssl rand -hex 32
   else
@@ -21,7 +28,6 @@ set_kv_if_empty() {
   local key="$1"
   local value="$2"
   if grep -qE "^${key}=$" "$ENV_FILE" || grep -qE "^${key}=[[:space:]]*$" "$ENV_FILE"; then
-    # Escape & for sed
     local escaped
     escaped="$(printf '%s' "$value" | sed -e 's/[&/\]/\\&/g')"
     sed -i.bak "s|^${key}=.*|${key}=${escaped}|" "$ENV_FILE"
@@ -29,30 +35,6 @@ set_kv_if_empty() {
     echo "Generated ${key}"
   fi
 }
-
-if [[ ! -f "$ENV_FILE" ]]; then
-  if [[ ! -f "$EXAMPLE_FILE" ]]; then
-    echo "Missing ${EXAMPLE_FILE}. Run this script from docs/deployment/hub-runtime/." >&2
-    exit 1
-  fi
-  cp "$EXAMPLE_FILE" "$ENV_FILE"
-  echo "Created ${ENV_FILE} from ${EXAMPLE_FILE}"
-fi
-
-# Fill empty secret fields (DB password is mirrored to POSTGRES_* for the db service)
-for key in SECRET_KEY JWT_SECRET_KEY JWT_REFRESH_SECRET_KEY JWT_RESET_SECRET_KEY JWT_VERIFICATION_SECRET_KEY ENCRYPT_KEY DATABASE_PASSWORD FIRST_SUPERUSER_PASSWORD; do
-  set_kv_if_empty "$key" "$(gen_secret)"
-done
-
-# Mirror app DB settings into Postgres container env (compose uses env_file only)
-db_user="$(grep -E '^DATABASE_USER=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
-db_pass="$(grep -E '^DATABASE_PASSWORD=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
-db_name="$(grep -E '^DATABASE_NAME=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
-db_user="${db_user:-postgres}"
-db_name="${db_name:-fastapi_db}"
-
-domain="$(grep -E '^DOMAIN=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
-domain="${domain:-rbac-api.mnfprofile.com}"
 
 sync_kv() {
   local key="$1"
@@ -67,65 +49,61 @@ sync_kv() {
   rm -f "${ENV_FILE}.bak"
 }
 
-# Production Settings require these (not secrets — stable JWT iss/aud + password-date floor)
-if ! grep -qE "^TOKEN_ISSUER=" "$ENV_FILE"; then
-  printf 'TOKEN_ISSUER=fastapi-rbac\n' >>"$ENV_FILE"
-  echo "Added TOKEN_ISSUER"
-else
-  set_kv_if_empty "TOKEN_ISSUER" "fastapi-rbac"
-fi
-if ! grep -qE "^TOKEN_AUDIENCE=" "$ENV_FILE"; then
-  printf 'TOKEN_AUDIENCE=%s\n' "$domain" >>"$ENV_FILE"
-  echo "Added TOKEN_AUDIENCE=${domain}"
-else
-  set_kv_if_empty "TOKEN_AUDIENCE" "$domain"
-fi
-if ! grep -qE "^USER_CHANGED_PASSWORD_DATE=" "$ENV_FILE"; then
-  printf 'USER_CHANGED_PASSWORD_DATE=2026-01-01\n' >>"$ENV_FILE"
-  echo "Added USER_CHANGED_PASSWORD_DATE"
-else
-  set_kv_if_empty "USER_CHANGED_PASSWORD_DATE" "2026-01-01"
-fi
+prepare_env() {
+  local db_user db_pass db_name domain
 
-sync_kv "POSTGRES_USER" "$db_user"
-sync_kv "POSTGRES_PASSWORD" "$db_pass"
-sync_kv "POSTGRES_DB" "$db_name"
-# Broker URLs for private Redis (no auth); keep Celery on the Compose network
-sync_kv "CELERY_BROKER_URL" "redis://redis:6379/0"
-sync_kv "CELERY_RESULT_BACKEND" "redis://redis:6379/0"
-echo "Synced POSTGRES_* and Celery broker URLs in ${ENV_FILE}"
-
-# SMTP must be provided for full-flow validation
-if grep -qE "^SMTP_HOST=(smtp\.example\.com)?[[:space:]]*$" "$ENV_FILE" || grep -qE "^SMTP_HOST=$" "$ENV_FILE"; then
-  echo "WARNING: Set SMTP_* in ${ENV_FILE} before relying on email flows." >&2
-fi
-
-if ! command -v docker >/dev/null 2>&1; then
-  echo "Docker is required. See oracle-always-free-setup.md." >&2
-  exit 1
-fi
-
-echo "Pulling images (IMAGE_TAG from ${ENV_FILE})..."
-docker compose --env-file "$ENV_FILE" -f compose.yml pull
-
-echo "Starting Hub runtime..."
-docker compose --env-file "$ENV_FILE" -f compose.yml up -d
-
-echo "Waiting for API health..."
-DOMAIN="$(grep -E '^DOMAIN=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
-DOMAIN="${DOMAIN:-rbac-api.mnfprofile.com}"
-
-for i in $(seq 1 60); do
-  if curl -fsS "https://${DOMAIN}/api/v1/health" >/dev/null 2>&1 || \
-     docker compose --env-file "$ENV_FILE" -f compose.yml exec -T api curl -fsS "http://localhost:8000/api/v1/health" >/dev/null 2>&1; then
-    echo "Hub runtime is up."
-    echo "API: https://${DOMAIN}/api/v1/health"
-    echo "OpenAPI: https://${DOMAIN}/docs"
-    echo "Superuser email is FIRST_SUPERUSER_EMAIL in ${ENV_FILE}"
-    exit 0
+  if [[ ! -f "$ENV_FILE" ]]; then
+    if [[ ! -f "$EXAMPLE_FILE" ]]; then
+      echo "Missing ${EXAMPLE_FILE}. Run this script from docs/deployment/hub-runtime/." >&2
+      exit 1
+    fi
+    cp "$EXAMPLE_FILE" "$ENV_FILE"
+    echo "Created ${ENV_FILE} from ${EXAMPLE_FILE}"
   fi
-  sleep 5
-done
 
-echo "Timed out waiting for healthy API. Check: docker compose -f compose.yml logs" >&2
-exit 1
+  for key in SECRET_KEY JWT_SECRET_KEY JWT_REFRESH_SECRET_KEY JWT_RESET_SECRET_KEY JWT_VERIFICATION_SECRET_KEY ENCRYPT_KEY DATABASE_PASSWORD FIRST_SUPERUSER_PASSWORD; do
+    set_kv_if_empty "$key" "$(gen_secret)"
+  done
+
+  db_user="$(grep -E '^DATABASE_USER=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
+  db_pass="$(grep -E '^DATABASE_PASSWORD=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
+  db_name="$(grep -E '^DATABASE_NAME=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
+  db_user="${db_user:-postgres}"
+  db_name="${db_name:-fastapi_db}"
+
+  domain="$(grep -E '^DOMAIN=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
+  domain="${domain:-rbac-api.mnfprofile.com}"
+
+  if ! grep -qE "^TOKEN_ISSUER=" "$ENV_FILE"; then
+    printf 'TOKEN_ISSUER=fastapi-rbac\n' >>"$ENV_FILE"
+    echo "Added TOKEN_ISSUER"
+  else
+    set_kv_if_empty "TOKEN_ISSUER" "fastapi-rbac"
+  fi
+  if ! grep -qE "^TOKEN_AUDIENCE=" "$ENV_FILE"; then
+    printf 'TOKEN_AUDIENCE=%s\n' "$domain" >>"$ENV_FILE"
+    echo "Added TOKEN_AUDIENCE=${domain}"
+  else
+    set_kv_if_empty "TOKEN_AUDIENCE" "$domain"
+  fi
+  if ! grep -qE "^USER_CHANGED_PASSWORD_DATE=" "$ENV_FILE"; then
+    printf 'USER_CHANGED_PASSWORD_DATE=2026-01-01\n' >>"$ENV_FILE"
+    echo "Added USER_CHANGED_PASSWORD_DATE"
+  else
+    set_kv_if_empty "USER_CHANGED_PASSWORD_DATE" "2026-01-01"
+  fi
+
+  sync_kv "POSTGRES_USER" "$db_user"
+  sync_kv "POSTGRES_PASSWORD" "$db_pass"
+  sync_kv "POSTGRES_DB" "$db_name"
+  # Broker URLs for private Redis (no auth); keep Celery on the Compose network
+  sync_kv "CELERY_BROKER_URL" "redis://redis:6379/0"
+  sync_kv "CELERY_RESULT_BACKEND" "redis://redis:6379/0"
+  echo "Synced POSTGRES_* and Celery broker URLs in ${ENV_FILE}"
+
+  if grep -qE "^SMTP_HOST=(smtp\.example\.com)?[[:space:]]*$" "$ENV_FILE" || grep -qE "^SMTP_HOST=$" "$ENV_FILE"; then
+    echo "WARNING: Set SMTP_* in ${ENV_FILE} before relying on email flows." >&2
+  fi
+}
+
+hub_bootstrap_main "$@"

--- a/docs/deployment/hub-runtime/index.md
+++ b/docs/deployment/hub-runtime/index.md
@@ -15,13 +15,14 @@ This is the same topology for staging and production-style validation. Admin UI 
 | --- | --- |
 | [`compose.yml`](./compose.yml) | One-package Compose: `caddy`, `api`, `worker`, `beat`, `db`, `redis` |
 | [`env.example`](./env.example) | Copy to `.env` on the host (never commit `.env`) |
-| [`bootstrap.sh`](./bootstrap.sh) | Generate empty secrets, pull images, start stack, wait for health |
+| [`bootstrap.sh`](./bootstrap.sh) | CLI: prepare `.env`, pull/start/stop, status, logs, health (default: `up`) |
+| [`_bootstrap_cli.sh`](./_bootstrap_cli.sh) | Shared subcommands/flags (sourced by one-box + split bootstraps) |
 | [`Caddyfile`](./Caddyfile) | TLS for `DOMAIN` → `api:8000` |
 | [Oracle Always Free first-time setup](./oracle-always-free-setup.md) | Free VM path for maintainers (single-VM Compose) |
 | [Split + managed data (alternative)](./split-managed-data.md) | Two AMD micros + Neon + Upstash; stop worker when idle |
 | [`split/compose.api.yml`](./split/compose.api.yml) | Edge only: Caddy + API |
 | [`split/compose.worker.yml`](./split/compose.worker.yml) | Worker + Beat only |
-| [`split/bootstrap-api.sh`](./split/bootstrap-api.sh) / [`bootstrap-worker.sh`](./split/bootstrap-worker.sh) | Per-role bootstrap (managed DB/Redis required) |
+| [`split/bootstrap-api.sh`](./split/bootstrap-api.sh) / [`bootstrap-worker.sh`](./split/bootstrap-worker.sh) | Same CLI for API edge / worker edge (managed DB/Redis required) |
 
 ## Quick start (VM already prepared)
 
@@ -30,12 +31,18 @@ cd docs/deployment/hub-runtime
 cp env.example .env
 # Edit .env: IMAGE_TAG, DOMAIN, SMTP_*, FIRST_SUPERUSER_EMAIL
 chmod +x bootstrap.sh
-./bootstrap.sh
+./bootstrap.sh --help
+./bootstrap.sh                 # same as: ./bootstrap.sh up
+./bootstrap.sh status
+./bootstrap.sh logs -f api
+./bootstrap.sh up api          # single service
+./bootstrap.sh health
 ```
 
 - Pin `IMAGE_TAG=vX.Y.Z` by default; set `IMAGE_TAG=latest` only for a quick check.
 - Default public host: `https://rbac-api.mnfprofile.com`
 - API health: `https://rbac-api.mnfprofile.com/api/v1/health`
+- Global flags: `--env-file`, `--no-pull`, `--no-wait`
 
 ## Related
 

--- a/docs/deployment/hub-runtime/oracle-always-free-setup.md
+++ b/docs/deployment/hub-runtime/oracle-always-free-setup.md
@@ -381,10 +381,13 @@ cp env.example .env
 nano .env   # or vim
 
 chmod +x bootstrap.sh
-./bootstrap.sh
+./bootstrap.sh --help
+./bootstrap.sh                 # prepare .env, pull, up, wait for health
+./bootstrap.sh status
+./bootstrap.sh logs -f worker
 ```
 
-`bootstrap.sh` fills empty `SECRET_KEY` / DB / Redis / superuser password fields, pulls Hub images, starts Compose, and waits for API health.
+`bootstrap.sh` fills empty `SECRET_KEY` / DB / Redis / superuser password fields, pulls Hub images, starts Compose, and waits for API health. Use `./bootstrap.sh up api` (or other services) to target one container; `env` only prepares `.env`.
 
 The API container entrypoint runs migrations and initial data (including the first superuser).
 
@@ -402,8 +405,8 @@ curl -fsS "https://rbac-api.mnfprofile.com/api/v1/health"
 Exercise login, a password-reset email (SMTP), and confirm worker/beat stay up:
 
 ```bash
-docker compose --env-file .env -f compose.yml ps
-docker compose --env-file .env -f compose.yml logs -f worker beat
+./bootstrap.sh status
+./bootstrap.sh logs -f worker beat
 ```
 
 With the Admin UI host live, also open `https://rbac.mnfprofile.com`, confirm login (no CORS errors), and that reset/verify email links use that host.
@@ -414,7 +417,7 @@ With the Admin UI host live, also open `https://rbac.mnfprofile.com`, confirm lo
 
 ```bash
 cd ~/fastapi_rbac/docs/deployment/hub-runtime   # or your path
-docker compose --env-file .env -f compose.yml down
+./bootstrap.sh down
 ```
 
 Optional: in Console → instance → **Stop** until the next test (avoids burning Always Free hours while idle; also reduces idle-reclaim risk from low utilization).

--- a/docs/deployment/hub-runtime/split-managed-data.md
+++ b/docs/deployment/hub-runtime/split-managed-data.md
@@ -41,9 +41,10 @@ Admin UI                        [Admin UI host](../admin-ui/index.md) (unchanged
 | [`split/env.example`](./split/env.example) | Copy to `.env` on **each** VM; fill Neon + Upstash (no `db` / `redis` hosts) |
 | [`split/compose.api.yml`](./split/compose.api.yml) | `caddy` + `api` only |
 | [`split/compose.worker.yml`](./split/compose.worker.yml) | `worker` + `beat` only |
-| [`split/bootstrap-api.sh`](./split/bootstrap-api.sh) | Secrets/JWT defaults, validate managed hosts, pull/up API stack, wait health |
-| [`split/bootstrap-worker.sh`](./split/bootstrap-worker.sh) | Same env checks, pull/up worker + Beat |
-| [`split/_common.sh`](./split/_common.sh) | Shared helpers (sourced by both bootstraps) |
+| [`split/bootstrap-api.sh`](./split/bootstrap-api.sh) | CLI for API edge (`up`/`status`/`logs`/`health`/…); managed hosts required |
+| [`split/bootstrap-worker.sh`](./split/bootstrap-worker.sh) | Same CLI for worker + Beat |
+| [`split/_common.sh`](./split/_common.sh) | Shared env/CA helpers (sourced by both bootstraps) |
+| [`_bootstrap_cli.sh`](./_bootstrap_cli.sh) | Shared subcommands/flags (parent of `split/`) |
 | [`Caddyfile`](./Caddyfile) | Shared with single-VM path (mounted as `../Caddyfile`) |
 
 Default single-VM [`bootstrap.sh`](./bootstrap.sh) still forces `CELERY_*` → `redis://redis:6379/0` for Compose Redis. **Split bootstraps never do that** — they require your managed URLs.
@@ -109,13 +110,18 @@ cd docs/deployment/hub-runtime/split
 cp env.example .env
 # Edit .env: Neon, Upstash, SMTP, FIRST_SUPERUSER_EMAIL, DOMAIN, IMAGE_TAG
 chmod +x bootstrap-api.sh bootstrap-worker.sh
-./bootstrap-api.sh
+./bootstrap-api.sh --help
+./bootstrap-api.sh                 # prepare .env, pull, up caddy+api, wait health
+./bootstrap-api.sh status
+./bootstrap-api.sh logs -f api
+./bootstrap-api.sh up api          # recreate API only
 ```
 
 6. Smoke:
 
 ```bash
-curl -fsS "https://${DOMAIN}/api/v1/health"
+./bootstrap-api.sh health
+# or: curl -fsS "https://${DOMAIN}/api/v1/health"
 ```
 
 7. Copy the finished `.env` to the worker VM (same secrets):
@@ -136,7 +142,11 @@ scp .env ubuntu@<worker-private-or-public-ip>:~/hub-split.env
 ```bash
 cd docs/deployment/hub-runtime/split
 chmod +x bootstrap-worker.sh
-./bootstrap-worker.sh
+./bootstrap-worker.sh --help
+./bootstrap-worker.sh              # pull + up worker + beat
+./bootstrap-worker.sh status
+./bootstrap-worker.sh logs -f worker
+./bootstrap-worker.sh restart worker
 ```
 
 5. When finished testing:

--- a/docs/deployment/hub-runtime/split/bootstrap-api.sh
+++ b/docs/deployment/hub-runtime/split/bootstrap-api.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Hub runtime SPLIT — API + Caddy on the edge VM (Neon/Upstash via .env).
+# Usage: ./bootstrap-api.sh [--help] [command] [args…]
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -8,39 +9,22 @@ cd "$ROOT_DIR"
 ENV_FILE="${ENV_FILE:-.env}"
 EXAMPLE_FILE="env.example"
 COMPOSE_FILE="compose.api.yml"
+HUB_ROLE="api"
+HUB_SERVICES="caddy api"
+SCRIPT_NAME="$(basename "$0")"
 
 # shellcheck source=_common.sh
 source "${ROOT_DIR}/_common.sh"
+# shellcheck source=../_bootstrap_cli.sh
+source "${ROOT_DIR}/../_bootstrap_cli.sh"
 
-ensure_env_file
-fill_secrets_and_tokens
-require_managed_data_env
-warn_smtp_if_placeholder
-require_docker
-require_host_ca_bundle
+prepare_env() {
+  ensure_env_file
+  fill_secrets_and_tokens
+  require_managed_data_env
+  warn_smtp_if_placeholder
+  require_docker
+  require_host_ca_bundle
+}
 
-echo "Pulling API edge images (IMAGE_TAG from ${ENV_FILE})..."
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull
-
-echo "Starting Hub runtime API edge (caddy + api)..."
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d
-
-DOMAIN="$(grep -E '^DOMAIN=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
-DOMAIN="${DOMAIN:-rbac-api.mnfprofile.com}"
-
-echo "Waiting for API health..."
-for _ in $(seq 1 60); do
-  if curl -fsS "https://${DOMAIN}/api/v1/health" >/dev/null 2>&1 || \
-     docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" exec -T api curl -fsS "http://localhost:8000/api/v1/health" >/dev/null 2>&1; then
-    echo "API edge is up."
-    echo "API: https://${DOMAIN}/api/v1/health"
-    echo "OpenAPI: https://${DOMAIN}/docs"
-    echo "Superuser email is FIRST_SUPERUSER_EMAIL in ${ENV_FILE}"
-    echo "Start the worker VM separately: ./bootstrap-worker.sh"
-    exit 0
-  fi
-  sleep 5
-done
-
-echo "Timed out waiting for healthy API. Check: docker compose -f ${COMPOSE_FILE} logs" >&2
-exit 1
+hub_bootstrap_main "$@"

--- a/docs/deployment/hub-runtime/split/bootstrap-worker.sh
+++ b/docs/deployment/hub-runtime/split/bootstrap-worker.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Hub runtime SPLIT — Celery worker + Beat (same .env data plane as the API VM).
+# Usage: ./bootstrap-worker.sh [--help] [command] [args…]
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -8,28 +9,24 @@ cd "$ROOT_DIR"
 ENV_FILE="${ENV_FILE:-.env}"
 EXAMPLE_FILE="env.example"
 COMPOSE_FILE="compose.worker.yml"
-
-# shellcheck source=_common.sh
-source "${ROOT_DIR}/_common.sh"
-
-ensure_env_file
-fill_secrets_and_tokens
-require_managed_data_env
-warn_smtp_if_placeholder
-require_docker
-require_host_ca_bundle
+HUB_ROLE="worker"
+HUB_SERVICES="worker beat"
+SCRIPT_NAME="$(basename "$0")"
 
 # Prefer scp/copy of the API VM .env so JWT/DB/Redis secrets match exactly.
 
-echo "Pulling worker images (IMAGE_TAG from ${ENV_FILE})..."
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull
+# shellcheck source=_common.sh
+source "${ROOT_DIR}/_common.sh"
+# shellcheck source=../_bootstrap_cli.sh
+source "${ROOT_DIR}/../_bootstrap_cli.sh"
 
-echo "Starting Hub runtime worker edge (worker + beat)..."
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d
+prepare_env() {
+  ensure_env_file
+  fill_secrets_and_tokens
+  require_managed_data_env
+  warn_smtp_if_placeholder
+  require_docker
+  require_host_ca_bundle
+}
 
-echo "Worker stack status:"
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" ps
-
-echo "Worker + Beat are up (or starting)."
-echo "Stop this OCI instance when you finish testing to save Always Free idle risk and Upstash commands."
-echo "Logs: docker compose --env-file ${ENV_FILE} -f ${COMPOSE_FILE} logs -f worker beat"
+hub_bootstrap_main "$@"


### PR DESCRIPTION
## Summary
- Add shared `_bootstrap_cli.sh` with subcommands (`up`, `down`, `restart`, `pull`, `status`, `logs`, `health`, `env`, `config`, `exec`) and flags (`--help`, `--env-file`, `--no-pull`, `--no-wait`).
- Wire one-box `bootstrap.sh` and split `bootstrap-api.sh` / `bootstrap-worker.sh` to the same CLI; no-args still runs full `up`.
- Document examples in hub-runtime index, Oracle setup, and split-managed-data.

## Test plan
- [ ] `./bootstrap.sh --help` (and api/worker variants) print role-specific services
- [ ] `./bootstrap.sh env` prepares `.env` without starting containers
- [ ] `./bootstrap.sh up` / `./bootstrap-api.sh up` / `./bootstrap-worker.sh up` behave as before
- [ ] `./bootstrap.sh status` and `logs -f api` work against a running stack
- [ ] Invalid service name is rejected with the valid list
