### PR TITLE
fix(deploy): stop Hub bootstrap silent exit on missing env keys

### DIFF
--- a/docs/deployment/hub-runtime/_bootstrap_cli.sh
+++ b/docs/deployment/hub-runtime/_bootstrap_cli.sh
@@ -81,9 +81,20 @@ hub_validate_services() {
   done
 }
 
+hub_env_get() {
+  local key="$1"
+  local line
+  line="$(grep -E "^${key}=" "$ENV_FILE" 2>/dev/null | tail -n1 || true)"
+  if [[ -z "$line" ]]; then
+    printf ''
+    return 0
+  fi
+  printf '%s' "${line#*=}" | tr -d '"' | tr -d "'" | tr -d '\r'
+}
+
 hub_domain() {
   local domain
-  domain="$(grep -E '^DOMAIN=' "$ENV_FILE" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'")"
+  domain="$(hub_env_get DOMAIN)"
   echo "${domain:-rbac-api.mnfprofile.com}"
 }
 
@@ -110,7 +121,11 @@ hub_wait_api_health() {
 }
 
 cmd_up() {
-  local services=("$@")
+  local -a services=()
+  if [[ $# -gt 0 ]]; then
+    services=("$@")
+  fi
+  echo "==> ${SCRIPT_NAME}: up (${HUB_ROLE})${services[*]:+ — ${services[*]}}"
   prepare_env
   hub_require_docker
   if [[ "${HUB_NO_PULL}" -eq 0 ]]; then
@@ -351,6 +366,15 @@ hub_bootstrap_main() {
         ;;
       --no-wait)
         HUB_NO_WAIT=1
+        shift
+        ;;
+      # Accept --up style for users who treat subcommands as flags
+      --up | --down | --restart | --pull | --status | --ps | --logs | --health | --env | --prepare | --config)
+        if [[ -n "$cmd" ]]; then
+          echo "Unexpected flag after command: $1" >&2
+          exit 1
+        fi
+        cmd="${1#--}"
         shift
         ;;
       up | down | restart | pull | status | ps | logs | health | env | prepare | config | exec)

--- a/docs/deployment/hub-runtime/bootstrap.sh
+++ b/docs/deployment/hub-runtime/bootstrap.sh
@@ -16,6 +16,17 @@ SCRIPT_NAME="$(basename "$0")"
 # shellcheck source=_bootstrap_cli.sh
 source "${ROOT_DIR}/_bootstrap_cli.sh"
 
+env_get() {
+  local key="$1"
+  local line
+  line="$(grep -E "^${key}=" "$ENV_FILE" 2>/dev/null | tail -n1 || true)"
+  if [[ -z "$line" ]]; then
+    printf ''
+    return 0
+  fi
+  printf '%s' "${line#*=}" | tr -d '"' | tr -d "'" | tr -d '\r'
+}
+
 gen_secret() {
   if command -v openssl >/dev/null 2>&1; then
     openssl rand -hex 32
@@ -65,13 +76,13 @@ prepare_env() {
     set_kv_if_empty "$key" "$(gen_secret)"
   done
 
-  db_user="$(grep -E '^DATABASE_USER=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
-  db_pass="$(grep -E '^DATABASE_PASSWORD=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
-  db_name="$(grep -E '^DATABASE_NAME=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
+  db_user="$(env_get DATABASE_USER)"
+  db_pass="$(env_get DATABASE_PASSWORD)"
+  db_name="$(env_get DATABASE_NAME)"
   db_user="${db_user:-postgres}"
   db_name="${db_name:-fastapi_db}"
 
-  domain="$(grep -E '^DOMAIN=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
+  domain="$(env_get DOMAIN)"
   domain="${domain:-rbac-api.mnfprofile.com}"
 
   if ! grep -qE "^TOKEN_ISSUER=" "$ENV_FILE"; then

--- a/docs/deployment/hub-runtime/split/_common.sh
+++ b/docs/deployment/hub-runtime/split/_common.sh
@@ -9,6 +9,19 @@ gen_secret() {
   fi
 }
 
+# Read KEY=value from ENV_FILE without tripping `set -e` when the key is absent.
+env_get() {
+  local key="$1"
+  local line
+  line="$(grep -E "^${key}=" "$ENV_FILE" 2>/dev/null | tail -n1 || true)"
+  if [[ -z "$line" ]]; then
+    printf ''
+    return 0
+  fi
+  # Strip CR so Windows/CRLF .env files do not yield a non-empty $'\r' value.
+  printf '%s' "${line#*=}" | tr -d '"' | tr -d "'" | tr -d '\r'
+}
+
 set_kv_if_empty() {
   local key="$1"
   local value="$2"
@@ -38,7 +51,7 @@ fill_secrets_and_tokens() {
     set_kv_if_empty "$key" "$(gen_secret)"
   done
 
-  domain="$(grep -E '^DOMAIN=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
+  domain="$(env_get DOMAIN)"
   domain="${domain:-rbac-api.mnfprofile.com}"
 
   if ! grep -qE "^TOKEN_ISSUER=" "$ENV_FILE"; then
@@ -63,10 +76,10 @@ fill_secrets_and_tokens() {
 
 require_managed_data_env() {
   local db_host redis_host broker backend
-  db_host="$(grep -E '^DATABASE_HOST=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
-  redis_host="$(grep -E '^REDIS_HOST=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
-  broker="$(grep -E '^CELERY_BROKER_URL=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
-  backend="$(grep -E '^CELERY_RESULT_BACKEND=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")"
+  db_host="$(env_get DATABASE_HOST)"
+  redis_host="$(env_get REDIS_HOST)"
+  broker="$(env_get CELERY_BROKER_URL)"
+  backend="$(env_get CELERY_RESULT_BACKEND)"
 
   if [[ -z "$db_host" || "$db_host" == "db" ]]; then
     echo "Set DATABASE_HOST in ${ENV_FILE} to your managed Postgres host (not Compose 'db')." >&2
@@ -106,7 +119,8 @@ require_docker() {
 
 require_host_ca_bundle() {
   local bundle
-  bundle="$(grep -E '^HOST_CA_BUNDLE=' "$ENV_FILE" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'")"
+  # Optional key (often commented in env.example). Must not use bare grep under set -e.
+  bundle="$(env_get HOST_CA_BUNDLE)"
   bundle="${bundle:-/etc/ssl/certs/ca-certificates.crt}"
   if [[ ! -f "$bundle" ]]; then
     echo "CA bundle not found at ${bundle}." >&2


### PR DESCRIPTION
## Summary
- Follow-up to #107: under `set -e`, looking up optional `HOST_CA_BUNDLE` with `grep` aborted the split bootstraps with **no output**.
- Read env via safe `env_get` (`|| true`), strip CR from CRLF `.env` values, print an `up` banner, and accept `--up`-style flags.

## Test plan
- [ ] `./bootstrap-api.sh up` prints `==> bootstrap-api.sh: up (api)` immediately
- [ ] With `HOST_CA_BUNDLE` commented/absent, script continues (uses default CA path) instead of silent exit
- [ ] Empty `DATABASE_HOST` fails with a clear error message
- [ ] `./bootstrap-worker.sh up` and `./bootstrap.sh up` still work
