### PR TITLE
fix(deploy): chown Celery beat schedule volume for appuser

### DIFF
--- a/docs/deployment/hub-runtime/compose.yml
+++ b/docs/deployment/hub-runtime/compose.yml
@@ -76,6 +76,9 @@ services:
   beat:
     image: mnaimfaizy/fastapi-rbac-worker:${IMAGE_TAG:-v1.2.3}
     restart: unless-stopped
+    # Named volumes are root-owned; image USER is appuser (uid 1000). Start as
+    # root only long enough to chown the schedule dir, then drop privileges.
+    user: "0:0"
     env_file:
       - .env
     environment:
@@ -90,7 +93,7 @@ services:
       [
         "/bin/bash",
         "-c",
-        "python ./app/backend_pre_start.py && exec celery -A app.celery_app beat --loglevel=info --schedule=/var/lib/celery/celerybeat-schedule.db",
+        "set -euo pipefail && mkdir -p /var/lib/celery && chown -R appuser:appuser /var/lib/celery && exec runuser -u appuser -- env PYTHONPATH=/app bash -c 'python ./app/backend_pre_start.py && exec celery -A app.worker:celery_app beat --loglevel=info --schedule=/var/lib/celery/celerybeat-schedule.db'",
       ]
     volumes:
       - beat_schedule:/var/lib/celery

--- a/docs/deployment/hub-runtime/split-managed-data.md
+++ b/docs/deployment/hub-runtime/split-managed-data.md
@@ -88,7 +88,7 @@ If `REDIS_HOST` includes `rediss://…@…:6379`, the app appends `:6379` again 
 
 Worker logs with an empty `[tasks]` list and `Received unregistered task of type 'app.worker…'` mean the process loaded `app.celery_app` without importing `app.worker`. Use `compose.worker.yml` as shipped (`celery -A app.worker:celery_app`) or a worker image that registers `imports=("app.worker",)`.
 
-Beat `Permission denied: '/var/lib/celery/celerybeat-schedule.db'`: the schedule volume is root-owned while the image runs as `appuser`. Current `compose.worker.yml` chowns that dir on start. After pulling the fix: `./bootstrap-worker.sh up --force-recreate` is not enough if compose is stale — `git pull` then `./bootstrap-worker.sh up beat` (or `docker compose ... up -d --force-recreate beat`).
+Beat `Permission denied: '/var/lib/celery/celerybeat-schedule.db'`: the schedule volume is root-owned while the image runs as `appuser`. Current `compose.worker.yml` chowns that dir on start. After pulling the fix: `git pull` then `docker compose --env-file .env -f compose.worker.yml up -d --force-recreate beat` (or `./bootstrap-worker.sh up beat` once the compose file is updated).
 
 3. **CA bundle:** production images require `/app/certs/ca.crt`. Split Compose mounts the host trust store (`/etc/ssl/certs/ca-certificates.crt`) there for Upstash public CAs. On the VM:
 

--- a/docs/deployment/hub-runtime/split-managed-data.md
+++ b/docs/deployment/hub-runtime/split-managed-data.md
@@ -88,6 +88,8 @@ If `REDIS_HOST` includes `rediss://…@…:6379`, the app appends `:6379` again 
 
 Worker logs with an empty `[tasks]` list and `Received unregistered task of type 'app.worker…'` mean the process loaded `app.celery_app` without importing `app.worker`. Use `compose.worker.yml` as shipped (`celery -A app.worker:celery_app`) or a worker image that registers `imports=("app.worker",)`.
 
+Beat `Permission denied: '/var/lib/celery/celerybeat-schedule.db'`: the schedule volume is root-owned while the image runs as `appuser`. Current `compose.worker.yml` chowns that dir on start. After pulling the fix: `./bootstrap-worker.sh up --force-recreate` is not enough if compose is stale — `git pull` then `./bootstrap-worker.sh up beat` (or `docker compose ... up -d --force-recreate beat`).
+
 3. **CA bundle:** production images require `/app/certs/ca.crt`. Split Compose mounts the host trust store (`/etc/ssl/certs/ca-certificates.crt`) there for Upstash public CAs. On the VM:
 
 ```bash

--- a/docs/deployment/hub-runtime/split/compose.worker.yml
+++ b/docs/deployment/hub-runtime/split/compose.worker.yml
@@ -32,6 +32,9 @@ services:
   beat:
     image: mnaimfaizy/fastapi-rbac-worker:${IMAGE_TAG:-v1.2.3}
     restart: unless-stopped
+    # Named volumes are root-owned; image USER is appuser (uid 1000). Start as
+    # root only long enough to chown the schedule dir, then drop privileges.
+    user: "0:0"
     env_file:
       - .env
     environment:
@@ -45,7 +48,7 @@ services:
       [
         "/bin/bash",
         "-c",
-        "python ./app/backend_pre_start.py && exec celery -A app.celery_app beat --loglevel=info --schedule=/var/lib/celery/celerybeat-schedule.db",
+        "set -euo pipefail && mkdir -p /var/lib/celery && chown -R appuser:appuser /var/lib/celery && exec runuser -u appuser -- env PYTHONPATH=/app bash -c 'python ./app/backend_pre_start.py && exec celery -A app.worker:celery_app beat --loglevel=info --schedule=/var/lib/celery/celerybeat-schedule.db'",
       ]
     depends_on:
       worker:


### PR DESCRIPTION
## Summary
- Beat failed with `Permission denied: /var/lib/celery/celerybeat-schedule.db` because the named volume is root-owned and the Hub worker image runs as `appuser`.
- One-box and split worker Compose: start beat as root, `chown` the schedule dir, then `runuser -u appuser` for Celery beat.
- Align beat app path with `app.worker:celery_app`.

## Test plan
- [ ] On worker VM: `git pull` and `./bootstrap-worker.sh up beat` (or recreate beat)
- [ ] `./bootstrap-worker.sh logs beat --tail=30` shows beat ready, no Permission denied
- [ ] `./bootstrap-worker.sh status` shows beat healthy/running

### Immediate workaround (before merge)
```bash
docker compose --env-file .env -f compose.worker.yml run --rm --user root beat \
  chown -R appuser:appuser /var/lib/celery
./bootstrap-worker.sh up beat
```
