### PR TITLE
fix(deploy): override Hub worker/beat Docker healthchecks

### DIFF
--- a/backend/queue.dockerfile.prod
+++ b/backend/queue.dockerfile.prod
@@ -97,9 +97,9 @@ RUN chown -R appuser:appuser /app
 # Switch to non-root user
 USER appuser
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD celery -A app.celery_app inspect ping || exit 1
+# Health check (worker). Compose overrides this for beat (inspect ping is worker-only).
+HEALTHCHECK --interval=60s --timeout=20s --start-period=120s --retries=3 \
+    CMD celery -A app.worker:celery_app inspect ping -t 10 || exit 1
 
 # The actual command will be specified in docker-compose
 CMD ["/bin/bash", "/app/scripts/docker/start-worker.sh"]

--- a/docs/deployment/hub-runtime/compose.yml
+++ b/docs/deployment/hub-runtime/compose.yml
@@ -63,6 +63,16 @@ services:
       REDIS_HOST: redis
       REDIS_SSL: "false"
     command: ["/bin/bash", "/app/scripts/docker/start-worker.sh"]
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "celery -A app.worker:celery_app inspect ping -t 10 >/dev/null 2>&1 || exit 1",
+        ]
+      interval: 60s
+      timeout: 20s
+      retries: 3
+      start_period: 120s
     depends_on:
       db:
         condition: service_healthy
@@ -97,6 +107,16 @@ services:
       ]
     volumes:
       - beat_schedule:/var/lib/celery
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import pathlib; raise SystemExit(0 if any(b'beat' in (pathlib.Path('/proc')/d/'cmdline').read_bytes() for d in pathlib.Path('/proc').iterdir() if d.name.isdigit()) else 1)\"",
+        ]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
     depends_on:
       db:
         condition: service_healthy

--- a/docs/deployment/hub-runtime/split-managed-data.md
+++ b/docs/deployment/hub-runtime/split-managed-data.md
@@ -90,6 +90,8 @@ Worker logs with an empty `[tasks]` list and `Received unregistered task of type
 
 Beat `Permission denied: '/var/lib/celery/celerybeat-schedule.db'`: the schedule volume is root-owned while the image runs as `appuser`. Current `compose.worker.yml` chowns that dir on start. After pulling the fix: `git pull` then `docker compose --env-file .env -f compose.worker.yml up -d --force-recreate beat` (or `./bootstrap-worker.sh up beat` once the compose file is updated).
 
+`STATUS … (unhealthy)` while logs show worker/beat ready: the worker image’s default HEALTHCHECK (`celery inspect ping` on `app.celery_app`) is a false negative for Hub (and is wrong for beat). Compose overrides healthchecks; recreate after pull: `docker compose --env-file .env -f compose.worker.yml up -d --force-recreate`.
+
 3. **CA bundle:** production images require `/app/certs/ca.crt`. Split Compose mounts the host trust store (`/etc/ssl/certs/ca-certificates.crt`) there for Upstash public CAs. On the VM:
 
 ```bash

--- a/docs/deployment/hub-runtime/split/compose.worker.yml
+++ b/docs/deployment/hub-runtime/split/compose.worker.yml
@@ -26,6 +26,17 @@ services:
         "-c",
         "export PYTHONPATH=/app && python ./app/backend_pre_start.py && exec celery -A app.worker:celery_app worker --loglevel=info -Q emails,maintenance,logging,user_management,default,periodic_tasks --concurrency=1",
       ]
+    # Image HEALTHCHECK uses app.celery_app + short timeouts; override for Hub/Upstash.
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "celery -A app.worker:celery_app inspect ping -t 10 >/dev/null 2>&1 || exit 1",
+        ]
+      interval: 60s
+      timeout: 20s
+      retries: 3
+      start_period: 120s
     networks:
       - hub_worker
 
@@ -53,6 +64,17 @@ services:
     depends_on:
       worker:
         condition: service_started
+    # Same image as worker: inherited inspect-ping HEALTHCHECK is for workers, not beat.
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import pathlib; raise SystemExit(0 if any(b'beat' in (pathlib.Path('/proc')/d/'cmdline').read_bytes() for d in pathlib.Path('/proc').iterdir() if d.name.isdigit()) else 1)\"",
+        ]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
     networks:
       - hub_worker
 


### PR DESCRIPTION
## Summary
- `Up (unhealthy)` on Hub worker/beat was a **false negative**: the image HEALTHCHECK runs `celery -A app.celery_app inspect ping`, which does not apply to beat and is flaky/short for Upstash.
- Split + one-box Compose: worker uses `app.worker:celery_app inspect ping` with longer timeouts; beat checks that a beat process is running.
- Update `queue.dockerfile.prod` HEALTHCHECK for the next published worker image (Compose override works on `v0.1.1-beta` now).

## Test plan
- [ ] `git pull` on worker VM
- [ ] `docker compose --env-file .env -f compose.worker.yml up -d --force-recreate`
- [ ] `./bootstrap-worker.sh status` shows healthy (after start_period ~2m)
- [ ] Confirm logs still show worker ready / `beat: Starting...`
